### PR TITLE
storybook : Tags 컴포넌트 구현

### DIFF
--- a/src/components/common/Tags.module.scss
+++ b/src/components/common/Tags.module.scss
@@ -1,0 +1,68 @@
+.tags {
+  display: flex;
+  flex-direction: row;
+
+  &-size {
+    &-md { gap: 12px; }
+    &-sm { gap:8px; }
+  }
+}
+
+.tag {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &-size {
+    &-md {
+      height: 40px;
+    }
+    &-sm {
+      height: 32px;
+    }
+  }
+}
+
+.radio {
+  display: none;
+  margin: 0;
+  &:checked + .label {
+    color: #f9f9f9;
+    background-color: #afd278;
+    border: 1px solid #afd278;
+  }
+}
+
+.label {
+  width: 100%;
+  height: -webkit-fill-available;
+
+  font-weight: 500;
+  font-style: normal;
+  text-align: center;
+  white-space: nowrap;
+
+  color: #222;  
+  background-color: #f9f9f9;
+  border: 1px solid #bbb;
+
+  &-size {
+    &-md {
+      font-size: 16px;
+      padding: 0 24px;
+      border-radius: 12px;
+      line-height: 40px;
+    }
+    &-sm {
+      font-size: 14px;
+      padding: 0 20px;
+      border-radius: 8px;
+      line-height: 32px;
+    }
+  }
+
+  &:hover{
+    border: 1px solid #afd278;
+  }
+}
+
+

--- a/src/components/common/Tags.tsx
+++ b/src/components/common/Tags.tsx
@@ -1,0 +1,43 @@
+import classNames from "classnames/bind";
+import styles from "./Tags.module.scss";
+import { useState } from "react";
+
+const cx = classNames.bind(styles);
+
+interface TagsProps {
+  size?: "sm" | "md";
+  isAll?: boolean;
+  theme?: "sunny" | "rainy" | "snowy";
+}
+
+const tagList: Array<"전체" | "학문" | "연예" | "게임" | "기타"> = [
+  "전체",
+  "학문",
+  "연예",
+  "게임",
+  "기타",
+];
+
+const Tags = ({ size = "md", isAll = true, theme = "sunny" }: TagsProps) => {
+  const filteredTagList = isAll ? tagList : tagList.slice(1);
+  return (
+    <div className={cx("tags", `tags-size-${size}`)}>
+      {filteredTagList.map((tag) => (
+        <div className={cx("tag", `tag-size-${size}`)}>
+          <input
+            id={tag}
+            type="radio"
+            name="Tags"
+            value={tag}
+            className={cx("radio")}
+          />
+          <label htmlFor={tag} className={cx("label", `label-size-${size}`)}>
+            {tag}
+          </label>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Tags;

--- a/src/stories/Tags.stories.ts
+++ b/src/stories/Tags.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import Tags from "@/components/common/Tags";
+
+const meta = {
+  title: "Tags",
+  component: Tags,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Tags>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Small: Story = {
+  args: {
+    size: "sm",
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    size: "md",
+  },
+};


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] UI 구현
- [ ] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- Radio 버튼을 사용하여 Tags 컴포넌트 구현하였습니다. 세부적인 이벤트는 추후 작성하여야 합니다.
- isAll Prop으로 '전체' 버튼을 활성화/비활성화 할 수 있습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #14 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/79896328/5c1dcd2b-9a53-4b15-a8e3-a1e031d77f52)
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/79896328/9086ed7f-d9e0-4646-8867-75f30ca963f6)

