### PR TITLE
PopUp에 에러 메세지 추가

### DIFF
--- a/src/components/common/PopUp/PopUp.module.scss
+++ b/src/components/common/PopUp/PopUp.module.scss
@@ -11,6 +11,12 @@
   background-color: $white;
   box-shadow: $popup-shadow;
 
+  // 궁금해서 넣어본 드래그 방지 코드입니당. 잘 되는구만
+  -webkit-user-select:none;
+  -moz-user-select:none;
+  -ms-user-select:none;
+  user-select:none;
+
   &-forms {
     display: flex;
     flex-direction: column;
@@ -20,6 +26,7 @@
   }
 
   &-form {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -30,6 +37,16 @@
       @include text-style(18, bold);
       color: $secondary;
       margin: 0;
+    }
+
+    &-error {
+      position: absolute;
+      left: 8px;
+      bottom: -16px;
+      margin: 0;
+
+      @include text-style-12;
+      color: $red;
     }
   }
 }

--- a/src/components/common/PopUp/PopUp.tsx
+++ b/src/components/common/PopUp/PopUp.tsx
@@ -38,6 +38,9 @@ const PopUp = ({}: PopUpProps) => {
               maxLength: { value: 4, message: '최대 4자만 입력 가능합니다.' }
             })}
           />
+          {errors.nickname && (
+            <p className={cx('popup-form-error')}>{errors.nickname.message}</p>
+          )}
         </div>
         <div className={cx('popup-form')}>
           <p className={cx('popup-form-label')}>비밀번호</p>
@@ -52,6 +55,9 @@ const PopUp = ({}: PopUpProps) => {
               pattern: { value: /^\d+$/, message: '숫자만 입력 가능합니다.' }
             })}
           />
+          {errors.password && (
+            <p className={cx('popup-form-error')}>{errors.password.message}</p>
+          )}
         </div>
       </div>
       <Button text="내 질문 보러 가기" size="md" type="submit" />


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- 에러 메세지 추가하였습니다.
- 궁금해서 겸사겸사 팝업에 텍스트 드래그 금지 코드도 넣어봤어용.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #45 

## 스크린샷, 녹화
<img width="235" alt="image" src="https://github.com/Important-is-Great-Youths/QuickQuestion/assets/79896328/9f03fd87-1059-4a9b-8dd8-43cc90581024">
