### PR TITLE
Input 컴포넌트 size prop에 responsive 추가

### DIFF
--- a/src/components/common/Input/Input.module.scss
+++ b/src/components/common/Input/Input.module.scss
@@ -1,6 +1,6 @@
 .input {
   border-radius: 12px;
-  @include text-style(16, bold);
+  @include text-style(16);
   width: 100%;
   color: $black;
   display: block;
@@ -19,6 +19,16 @@
       @include text-style(14);
       height: 40px;
       padding: 0px 12px;
+    }
+    &-responsive {
+      height: 48px;
+      padding: 0px 16px;
+      @include responsive(M) {
+        border-radius: 8px;
+        @include text-style(14);
+        height: 40px;
+        padding: 0px 12px;
+      }
     }
   }
 }

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -5,7 +5,7 @@ import styles from './Input.module.scss'
 const cx = classNames.bind(styles)
 
 interface InputProps {
-  size: 'lg' | 'md'
+  size: 'lg' | 'md' | 'responsive'
   type: 'text' | 'password'
   id?: string
   placeholder?: string

--- a/src/components/home/QuestionForm/QuestionForm.tsx
+++ b/src/components/home/QuestionForm/QuestionForm.tsx
@@ -50,7 +50,7 @@ const QuestionForm = () => {
             </label>
             <Input
               id="nickName"
-              size="lg"
+              size="responsive"
               type="text"
               placeholder={PLACEHOLDER.nickname}
               {...register('nickName', {
@@ -76,7 +76,7 @@ const QuestionForm = () => {
             </label>
             <Input
               id="password"
-              size="lg"
+              size="responsive"
               type="text"
               placeholder={PLACEHOLDER.password}
               {...register('password')}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] UI 구현
- [ ] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
Input 컴포넌트 size prop에 responsive 추가하여 고정 사이즈 외에 반응형 사이즈도 적용할 수 있게 했습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #60 

