### PR TITLE
QuestionForm에 validation 설정 및 사진 첨부 기능 구현

### DIFF
--- a/src/apis/recipients.ts
+++ b/src/apis/recipients.ts
@@ -58,16 +58,3 @@ export const postRecipientsReactionsCreate = async (
   const res = await instance.get(`recipients/${id}/reactions/`, value)
   return res.data
 }
-
-export const postImageUrlCreate = async (formData: FormData) => {
-  const res = await instance.post(
-    'https://api.imgbb.com/1/upload?key=76c9edc5314add556ab072dbb9120f8b',
-    formData,
-    {
-      headers: {
-        'Content-Type': 'multipart/form-data'
-      }
-    }
-  )
-  return res.data
-}

--- a/src/apis/recipients.ts
+++ b/src/apis/recipients.ts
@@ -58,3 +58,16 @@ export const postRecipientsReactionsCreate = async (
   const res = await instance.get(`recipients/${id}/reactions/`, value)
   return res.data
 }
+
+export const postImageUrlCreate = async (formData: FormData) => {
+  const res = await instance.post(
+    'https://api.imgbb.com/1/upload?key=76c9edc5314add556ab072dbb9120f8b',
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data'
+      }
+    }
+  )
+  return res.data
+}

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -9,16 +9,18 @@ interface InputProps {
   type: 'text' | 'password'
   id?: string
   placeholder?: string
+  maxLength?: number
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ size, type, id, placeholder, ...props }, ref) => {
+  ({ size, type, id, placeholder, maxLength, ...props }, ref) => {
     return (
       <input
         className={cx('input', `input-size-${size}`)}
         type={type}
         id={id}
         placeholder={placeholder}
+        maxLength={maxLength}
         ref={ref}
         {...props}
       />

--- a/src/components/common/Tags/Tags.module.scss
+++ b/src/components/common/Tags/Tags.module.scss
@@ -47,7 +47,7 @@
 
   @include responsive(M) {
     font-size: 14px;
-    padding: 0 16px;
+    padding: 0 20px;
     border-radius: 8px;
     line-height: 32px;
   }

--- a/src/components/common/Tags/Tags.module.scss
+++ b/src/components/common/Tags/Tags.module.scss
@@ -47,7 +47,7 @@
 
   @include responsive(M) {
     font-size: 14px;
-    padding: 0 20px;
+    padding: 0 16px;
     border-radius: 8px;
     line-height: 32px;
   }

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import classNames from 'classnames/bind'
 
 import styles from './Textarea.module.scss'
@@ -8,22 +7,17 @@ const cx = classNames.bind(styles)
 interface TextareaProps {
   id: string
   placeholder: string
-  maxLength?: number
 }
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ id, placeholder, maxLength, ...props }, ref) => {
-    return (
-      <textarea
-        className={cx('textarea')}
-        id={id}
-        placeholder={placeholder}
-        ref={ref}
-        maxLength={maxLength}
-        {...props}
-      />
-    )
-  }
-)
+const Textarea = ({ id, placeholder, ...props }: TextareaProps) => {
+  return (
+    <textarea
+      className={cx('textarea')}
+      id={id}
+      placeholder={placeholder}
+      {...props}
+    />
+  )
+}
 
 export default Textarea

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import classNames from 'classnames/bind'
 
 import styles from './Textarea.module.scss'
@@ -7,17 +8,22 @@ const cx = classNames.bind(styles)
 interface TextareaProps {
   id: string
   placeholder: string
+  maxLength?: number
 }
 
-const Textarea = ({ id, placeholder, ...props }: TextareaProps) => {
-  return (
-    <textarea
-      className={cx('textarea')}
-      id={id}
-      placeholder={placeholder}
-      {...props}
-    />
-  )
-}
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ id, placeholder, maxLength, ...props }, ref) => {
+    return (
+      <textarea
+        className={cx('textarea')}
+        id={id}
+        placeholder={placeholder}
+        ref={ref}
+        maxLength={maxLength}
+        {...props}
+      />
+    )
+  }
+)
 
 export default Textarea

--- a/src/components/home/QuestionForm/QuestionForm.module.scss
+++ b/src/components/home/QuestionForm/QuestionForm.module.scss
@@ -52,14 +52,64 @@
     }
 
     &-image {
+      width: 140px;
+      height: 140px;
+      border: solid 1px $gray20;
+      border-radius: 16px;
+      cursor: pointer;
+      overflow: hidden;
+
+      &-wrap {
+        position: relative;
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+
+        &-icon {
+          position: absolute;
+          top: 50%;
+          display: none;
+          color: $white;
+          z-index: $popup-level;
+          transform: translateY(-50%);
+        }
+
+        &:hover &-icon {
+          display: block;
+        }
+
+        &::after {
+          position: absolute;
+          display: none;
+          width: 100%;
+          height: 100%;
+          background-color: $black;
+          content: '';
+          opacity: 0.5;
+        }
+
+        &:hover::after {
+          display: block;
+        }
+      }
+
+      &-preview {
+        position: relative;
+        width: 100%;
+        height: 100%;
+
+        &-cover {
+          object-fit: cover;
+        }
+      }
+
       &-label {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 140px;
-        height: 140px;
-        border: solid 1px $gray20;
-        border-radius: 16px;
+        width: 100%;
+        height: 100%;
         cursor: pointer;
       }
 

--- a/src/components/home/QuestionForm/QuestionForm.module.scss
+++ b/src/components/home/QuestionForm/QuestionForm.module.scss
@@ -52,64 +52,14 @@
     }
 
     &-image {
-      width: 140px;
-      height: 140px;
-      border: solid 1px $gray20;
-      border-radius: 16px;
-      cursor: pointer;
-      overflow: hidden;
-
-      &-wrap {
-        position: relative;
-        display: flex;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-
-        &-icon {
-          position: absolute;
-          top: 50%;
-          display: none;
-          color: $white;
-          z-index: $popup-level;
-          transform: translateY(-50%);
-        }
-
-        &:hover &-icon {
-          display: block;
-        }
-
-        &::after {
-          position: absolute;
-          display: none;
-          width: 100%;
-          height: 100%;
-          background-color: $black;
-          content: '';
-          opacity: 0.5;
-        }
-
-        &:hover::after {
-          display: block;
-        }
-      }
-
-      &-preview {
-        position: relative;
-        width: 100%;
-        height: 100%;
-
-        &-cover {
-          object-fit: cover;
-        }
-      }
-
       &-label {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 100%;
-        height: 100%;
+        width: 140px;
+        height: 140px;
+        border: solid 1px $gray20;
+        border-radius: 16px;
         cursor: pointer;
       }
 

--- a/src/components/home/QuestionForm/QuestionForm.tsx
+++ b/src/components/home/QuestionForm/QuestionForm.tsx
@@ -1,15 +1,12 @@
-import { useState } from 'react'
-import Image from 'next/image'
 import { useForm, SubmitHandler, FieldValues } from 'react-hook-form'
 import classNames from 'classnames/bind'
-import { Plus, X } from 'lucide-react'
+import { Plus } from 'lucide-react'
 
 import { GetRecipientsList } from '@/types/recipients'
 import { ERROR_MESSAGE, PLACEHOLDER } from '@/constants/formMessage'
 import {
   useGetRecipientsList,
-  usePostRecipientsCreate,
-  usePostImageUrlCreate
+  usePostRecipientsCreate
 } from '@/hooks/useRecipients'
 import Textarea from '@/components/common/Textarea/Textarea'
 import Input from '@/components/common/Input/Input'
@@ -21,53 +18,20 @@ import styles from './QuestionForm.module.scss'
 const cx = classNames.bind(styles)
 
 const QuestionForm = () => {
-  const [imagePreview, setImagePreview] = useState('')
-
   const { data } = useGetRecipientsList(100)
   const { mutate } = usePostRecipientsCreate()
-  const {
-    mutate: getImageUrl,
-    isSuccess: isSuccessGetImageUrl,
-    data: imageUrlData
-  } = usePostImageUrlCreate()
+  console.log(data)
 
   const {
     register,
     handleSubmit,
-    setValue,
     formState: { errors }
   } = useForm()
-
-  const handleCreateImageUrl = async (
-    value: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    if (value.target.files) {
-      setImagePreview(URL?.createObjectURL(value.target.files[0]))
-
-      const formData = new FormData()
-      formData.append('image', value.target.files[0])
-      getImageUrl(formData)
-    }
-  }
-
-  const handleResetImage = () => {
-    setValue('backgroundImageURL', '')
-    setImagePreview('')
-  }
-
-  if (isSuccessGetImageUrl) {
-    setValue('backgroundImageURL', imageUrlData.data.url)
-  }
 
   const onSubmit: SubmitHandler<FieldValues> = (value: FieldValues) => {
     value.name = `${value.nickName}/${value.password}/${value.question}`
 
-    const { question, nickName, password, backgroundImageSelect, ...values } =
-      value
-
-    const newValue = { ...values, ...{ team: '2-3' } }
-
-    // mutate(newValue)
+    const newValue = { ...value, ...{ team: '2-3' } }
   }
 
   return (
@@ -77,21 +41,7 @@ const QuestionForm = () => {
           <label className={cx('label')} htmlFor="question">
             질문 내용
           </label>
-          <Textarea
-            id="question"
-            placeholder={PLACEHOLDER.question}
-            maxLength={30}
-            {...register('question', {
-              required: ERROR_MESSAGE.question.required,
-              minLength: { value: 5, message: ERROR_MESSAGE.question.min },
-              maxLength: { value: 30, message: ERROR_MESSAGE.question.max }
-            })}
-          />
-          {errors.question && (
-            <p className={cx('form-field-message')}>
-              {errors.question.message?.toString()}
-            </p>
-          )}
+          <Textarea id="question" placeholder={PLACEHOLDER.question} />
         </div>
         <div className={cx('responsive-flex')}>
           <div className={cx('responsive-flex-item')}>
@@ -103,13 +53,8 @@ const QuestionForm = () => {
               size="responsive"
               type="text"
               placeholder={PLACEHOLDER.nickname}
-              maxLength={4}
               {...register('nickName', {
                 required: ERROR_MESSAGE.nickname.required,
-                maxLength: {
-                  value: 4,
-                  message: ERROR_MESSAGE.nickname.required
-                },
                 validate: (value) =>
                   data.results.some(
                     (user: GetRecipientsList) =>
@@ -134,22 +79,7 @@ const QuestionForm = () => {
               size="responsive"
               type="text"
               placeholder={PLACEHOLDER.password}
-              maxLength={4}
-              {...register('password', {
-                required: ERROR_MESSAGE.password.required,
-                minLength: {
-                  value: 4,
-                  message: ERROR_MESSAGE.password.letters
-                },
-                maxLength: {
-                  value: 4,
-                  message: ERROR_MESSAGE.password.letters
-                },
-                pattern: {
-                  value: /^\d{4}$/,
-                  message: ERROR_MESSAGE.password.number
-                }
-              })}
+              {...register('password')}
             />
             {errors.password && (
               <p className={cx('form-field-message')}>
@@ -166,41 +96,21 @@ const QuestionForm = () => {
         </div>
         <div>
           <label className={cx('label')}>사진 (선택)</label>
-          <div className={cx('form-field-image')}>
-            {imagePreview ? (
-              <div
-                className={cx('form-field-image-wrap')}
-                onClick={handleResetImage}
-              >
-                <div className={cx('form-field-image-preview')}>
-                  <Image
-                    className={cx('form-field-image-preview-cover')}
-                    src={imagePreview}
-                    alt="질문 등록 첨부 사진"
-                    fill
-                    sizes="100%"
-                  />
-                </div>
-                <X className={cx('form-field-image-wrap-icon')} />
-              </div>
-            ) : (
-              <>
-                <label
-                  className={cx('form-field-image-label')}
-                  htmlFor="backgroundImageSelect"
-                >
-                  <Plus className={cx('form-field-image-icon')} />
-                </label>
-                <input
-                  className={cx('form-field-image-input')}
-                  id="backgroundImageSelect"
-                  type="file"
-                  {...register('backgroundImageSelect', {
-                    onChange: (value) => handleCreateImageUrl(value)
-                  })}
-                />
-              </>
-            )}
+          <div>
+            <label
+              className={cx('form-field-image-label')}
+              htmlFor="backgroundImageSelect"
+            >
+              <Plus className={cx('form-field-image-icon')} />
+            </label>
+            <input
+              className={cx('form-field-image-input')}
+              id="backgroundImageSelect"
+              type="file"
+              // {...register('backgroundImageSelect', {
+              //   onChange: (value) => handleCreateImageUrl(value)
+              // })}
+            />
           </div>
         </div>
       </div>

--- a/src/components/home/QuestionForm/QuestionForm.tsx
+++ b/src/components/home/QuestionForm/QuestionForm.tsx
@@ -1,12 +1,15 @@
+import { useState } from 'react'
+import Image from 'next/image'
 import { useForm, SubmitHandler, FieldValues } from 'react-hook-form'
 import classNames from 'classnames/bind'
-import { Plus } from 'lucide-react'
+import { Plus, X } from 'lucide-react'
 
 import { GetRecipientsList } from '@/types/recipients'
 import { ERROR_MESSAGE, PLACEHOLDER } from '@/constants/formMessage'
 import {
   useGetRecipientsList,
-  usePostRecipientsCreate
+  usePostRecipientsCreate,
+  usePostImageUrlCreate
 } from '@/hooks/useRecipients'
 import Textarea from '@/components/common/Textarea/Textarea'
 import Input from '@/components/common/Input/Input'
@@ -18,20 +21,53 @@ import styles from './QuestionForm.module.scss'
 const cx = classNames.bind(styles)
 
 const QuestionForm = () => {
+  const [imagePreview, setImagePreview] = useState('')
+
   const { data } = useGetRecipientsList(100)
   const { mutate } = usePostRecipientsCreate()
-  console.log(data)
+  const {
+    mutate: getImageUrl,
+    isSuccess: isSuccessGetImageUrl,
+    data: imageUrlData
+  } = usePostImageUrlCreate()
 
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors }
   } = useForm()
+
+  const handleCreateImageUrl = async (
+    value: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    if (value.target.files) {
+      setImagePreview(URL?.createObjectURL(value.target.files[0]))
+
+      const formData = new FormData()
+      formData.append('image', value.target.files[0])
+      getImageUrl(formData)
+    }
+  }
+
+  const handleResetImage = () => {
+    setValue('backgroundImageURL', '')
+    setImagePreview('')
+  }
+
+  if (isSuccessGetImageUrl) {
+    setValue('backgroundImageURL', imageUrlData.data.url)
+  }
 
   const onSubmit: SubmitHandler<FieldValues> = (value: FieldValues) => {
     value.name = `${value.nickName}/${value.password}/${value.question}`
 
-    const newValue = { ...value, ...{ team: '2-3' } }
+    const { question, nickName, password, backgroundImageSelect, ...values } =
+      value
+
+    const newValue = { ...values, ...{ team: '2-3' } }
+
+    // mutate(newValue)
   }
 
   return (
@@ -41,7 +77,21 @@ const QuestionForm = () => {
           <label className={cx('label')} htmlFor="question">
             질문 내용
           </label>
-          <Textarea id="question" placeholder={PLACEHOLDER.question} />
+          <Textarea
+            id="question"
+            placeholder={PLACEHOLDER.question}
+            maxLength={30}
+            {...register('question', {
+              required: ERROR_MESSAGE.question.required,
+              minLength: { value: 5, message: ERROR_MESSAGE.question.min },
+              maxLength: { value: 30, message: ERROR_MESSAGE.question.max }
+            })}
+          />
+          {errors.question && (
+            <p className={cx('form-field-message')}>
+              {errors.question.message?.toString()}
+            </p>
+          )}
         </div>
         <div className={cx('responsive-flex')}>
           <div className={cx('responsive-flex-item')}>
@@ -53,8 +103,13 @@ const QuestionForm = () => {
               size="responsive"
               type="text"
               placeholder={PLACEHOLDER.nickname}
+              maxLength={4}
               {...register('nickName', {
                 required: ERROR_MESSAGE.nickname.required,
+                maxLength: {
+                  value: 4,
+                  message: ERROR_MESSAGE.nickname.required
+                },
                 validate: (value) =>
                   data.results.some(
                     (user: GetRecipientsList) =>
@@ -79,7 +134,22 @@ const QuestionForm = () => {
               size="responsive"
               type="text"
               placeholder={PLACEHOLDER.password}
-              {...register('password')}
+              maxLength={4}
+              {...register('password', {
+                required: ERROR_MESSAGE.password.required,
+                minLength: {
+                  value: 4,
+                  message: ERROR_MESSAGE.password.letters
+                },
+                maxLength: {
+                  value: 4,
+                  message: ERROR_MESSAGE.password.letters
+                },
+                pattern: {
+                  value: /^\d{4}$/,
+                  message: ERROR_MESSAGE.password.number
+                }
+              })}
             />
             {errors.password && (
               <p className={cx('form-field-message')}>
@@ -96,21 +166,41 @@ const QuestionForm = () => {
         </div>
         <div>
           <label className={cx('label')}>사진 (선택)</label>
-          <div>
-            <label
-              className={cx('form-field-image-label')}
-              htmlFor="backgroundImageSelect"
-            >
-              <Plus className={cx('form-field-image-icon')} />
-            </label>
-            <input
-              className={cx('form-field-image-input')}
-              id="backgroundImageSelect"
-              type="file"
-              // {...register('backgroundImageSelect', {
-              //   onChange: (value) => handleCreateImageUrl(value)
-              // })}
-            />
+          <div className={cx('form-field-image')}>
+            {imagePreview ? (
+              <div
+                className={cx('form-field-image-wrap')}
+                onClick={handleResetImage}
+              >
+                <div className={cx('form-field-image-preview')}>
+                  <Image
+                    className={cx('form-field-image-preview-cover')}
+                    src={imagePreview}
+                    alt="질문 등록 첨부 사진"
+                    fill
+                    sizes="100%"
+                  />
+                </div>
+                <X className={cx('form-field-image-wrap-icon')} />
+              </div>
+            ) : (
+              <>
+                <label
+                  className={cx('form-field-image-label')}
+                  htmlFor="backgroundImageSelect"
+                >
+                  <Plus className={cx('form-field-image-icon')} />
+                </label>
+                <input
+                  className={cx('form-field-image-input')}
+                  id="backgroundImageSelect"
+                  type="file"
+                  {...register('backgroundImageSelect', {
+                    onChange: (value) => handleCreateImageUrl(value)
+                  })}
+                />
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/hooks/useRecipients.ts
+++ b/src/hooks/useRecipients.ts
@@ -1,13 +1,12 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 
-import {
-  getRecipientsList,
-  postRecipientsCreate,
-  postImageUrlCreate
-} from '@/apis/recipients'
+import { getRecipientsList, postRecipientsCreate } from '@/apis/recipients'
 import { PostRecipientsCreate } from '@/types/recipients'
 
-export const useGetRecipientsList = (limit?: number, offset?: number) =>
+export const useGetRecipientsList = (
+  limit?: number,
+  offset?: number
+) =>
   useQuery({
     queryKey: ['recipientsList'],
     queryFn: () => getRecipientsList(limit, offset)
@@ -16,9 +15,4 @@ export const useGetRecipientsList = (limit?: number, offset?: number) =>
 export const usePostRecipientsCreate = () =>
   useMutation({
     mutationFn: (value: PostRecipientsCreate) => postRecipientsCreate(value)
-  })
-
-export const usePostImageUrlCreate = () =>
-  useMutation({
-    mutationFn: (formData: FormData) => postImageUrlCreate(formData)
   })

--- a/src/hooks/useRecipients.ts
+++ b/src/hooks/useRecipients.ts
@@ -1,12 +1,13 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 
-import { getRecipientsList, postRecipientsCreate } from '@/apis/recipients'
+import {
+  getRecipientsList,
+  postRecipientsCreate,
+  postImageUrlCreate
+} from '@/apis/recipients'
 import { PostRecipientsCreate } from '@/types/recipients'
 
-export const useGetRecipientsList = (
-  limit?: number,
-  offset?: number
-) =>
+export const useGetRecipientsList = (limit?: number, offset?: number) =>
   useQuery({
     queryKey: ['recipientsList'],
     queryFn: () => getRecipientsList(limit, offset)
@@ -15,4 +16,9 @@ export const useGetRecipientsList = (
 export const usePostRecipientsCreate = () =>
   useMutation({
     mutationFn: (value: PostRecipientsCreate) => postRecipientsCreate(value)
+  })
+
+export const usePostImageUrlCreate = () =>
+  useMutation({
+    mutationFn: (formData: FormData) => postImageUrlCreate(formData)
   })

--- a/src/types/recipients.ts
+++ b/src/types/recipients.ts
@@ -12,7 +12,7 @@ export interface GetRecipientsList {
 
 export interface PostRecipientsCreate {
   team: string
-  name?: string
-  backgroundColor?: string
+  name: string
+  backgroundColor: string
   backgroundImageURL?: string | undefined
 }

--- a/src/types/recipients.ts
+++ b/src/types/recipients.ts
@@ -12,7 +12,7 @@ export interface GetRecipientsList {
 
 export interface PostRecipientsCreate {
   team: string
-  name: string
-  backgroundColor: string
+  name?: string
+  backgroundColor?: string
   backgroundImageURL?: string | undefined
 }


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
1. QuestionForm에 사진 첨부 및 삭제 기능을 구현했습니다.
2. QuestionForm에 validation 설정하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #62 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/96277798/e38b1a98-77a2-44c0-8ff4-f69f594f4abc)
