### PR TITLE
Tags를 react-hook-form 사용 가능한 꼴로 수정

### DIFF
--- a/src/components/common/PopUp/FindPopUp.tsx
+++ b/src/components/common/PopUp/FindPopUp.tsx
@@ -30,7 +30,7 @@ const FindPopUp = ({}: FindPopUpProps) => {
         <div className={cx('findpopup-form')}>
           <p className={cx('findpopup-form-label')}>닉네임</p>
           <Input
-            size="sm"
+            size="md"
             type="text"
             placeholder="닉네임을 입력해주세요"
             {...register('nickname', {
@@ -47,7 +47,7 @@ const FindPopUp = ({}: FindPopUpProps) => {
         <div className={cx('findpopup-form')}>
           <p className={cx('findpopup-form-label')}>비밀번호</p>
           <Input
-            size="sm"
+            size="md"
             type="password"
             placeholder="비밀번호를 입력해주세요"
             {...register('password', {

--- a/src/components/common/PopUp/PwPopUp.tsx
+++ b/src/components/common/PopUp/PwPopUp.tsx
@@ -32,7 +32,7 @@ const PwPopUp = ({}: PwPopUpProps) => {
       <div className={cx('pwpopup-inputbox')}>
         <div className={cx('pwpopup-inputbox-input')}>
           <Input
-            size="sm"
+            size="md"
             type="password"
             placeholder="****"
             {...register('password', {

--- a/src/components/common/Tags/Tags.tsx
+++ b/src/components/common/Tags/Tags.tsx
@@ -1,8 +1,8 @@
 import classNames from "classnames/bind";
 import styles from "./Tags.module.scss";
-import { useState } from "react";
+import { useFormContext } from 'react-hook-form'
 
-const cx = classNames.bind(styles);
+const cx = classNames.bind(styles)
 
 interface TagsProps {
   isAll?: boolean
@@ -17,17 +17,19 @@ const tagList: Array<'전체' | '학문' | '연예' | '게임' | '기타'> = [
 ]
 
 const Tags = ({ isAll = true }: TagsProps) => {
+  const { register } = useFormContext()
   const filteredTagList = isAll ? tagList : tagList.slice(1)
+
   return (
     <div className={cx('tags')}>
       {filteredTagList.map((tag) => (
-        <div className={cx('tag')}>
+        <div key={tag} className={cx('tag')}>
           <input
             id={tag}
             type="radio"
-            name="Tags"
             value={tag}
             className={cx('radio')}
+            {...register('tags', { required: '분야를 선택해주세요' })}
           />
           <label htmlFor={tag} className={cx('label')}>
             {tag}

--- a/src/components/common/TestModal/TestModal.tsx
+++ b/src/components/common/TestModal/TestModal.tsx
@@ -1,0 +1,18 @@
+// FormProvider 사용 예시입니다. Tags 컴포넌트 사용시 참고해주세요.
+import { FormProvider, useForm } from 'react-hook-form'
+import Tags from '../Tags/Tags'
+
+const TestModal = () => {
+  const methods = useForm()
+  const onSubmit = (data) => console.log(data)
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)}>
+        <Tags />
+        <button type="submit">Submit</button>
+      </form>
+    </FormProvider>
+  )
+}
+
+export default TestModal

--- a/src/stories/FindPopUp.stories.ts
+++ b/src/stories/FindPopUp.stories.ts
@@ -1,15 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { fn } from '@storybook/test'
-import PopUp from '@/components/common/PopUp/PopUp'
+import FindPopUp from '@/components/common/PopUp/FindPopUp'
 
 const meta = {
-  title: 'PopUp',
-  component: PopUp,
+  title: 'FindPopUp',
+  component: FindPopUp,
   parameters: {
     layout: 'centered'
   },
   tags: ['autodocs']
-} satisfies Meta<typeof PopUp>
+} satisfies Meta<typeof FindPopUp>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/src/stories/Input.stories.ts
+++ b/src/stories/Input.stories.ts
@@ -3,7 +3,8 @@ import Input from '@/components/common/Input/Input'
 
 const meta = {
   title: 'Input',
-  component: Input
+  component: Input,
+  tags: ['autodocs']
 } satisfies Meta<typeof Input>
 
 export default meta

--- a/src/stories/TestModal.stories.ts
+++ b/src/stories/TestModal.stories.ts
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+import TestModal from '@/components/common/TestModal/TestModal'
+
+const meta = {
+  title: 'TestModal',
+  component: TestModal,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof TestModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {}
+}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [ ] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- 아래와 같은 꼴로 사용해주셔야합니다.
```tsx
// FormProvider 사용 예시입니다. Tags 컴포넌트 사용시 참고해주세요.
import { FormProvider, useForm } from 'react-hook-form'
import Tags from '../Tags/Tags'

const TestModal = () => {
  const methods = useForm()
  const onSubmit = (data) => console.log(data)
  return (
    <FormProvider {...methods}>
      <form onSubmit={methods.handleSubmit(onSubmit)}>
        <Tags />
        <button type="submit">Submit</button>
      </form>
    </FormProvider>
  )
}

export default TestModal
```
- TestModal은 필요 없으시면 그냥 삭제하셔도 괜찮습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #64

## 스크린샷, 녹화
