### PR TITLE
tag 컴포넌트 사용하는 코드 및 비밀번호 input type이 아이콘에 따라 변경되도록 수정

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -9,7 +9,7 @@ const queryClient = new QueryClient()
 
 export function Providers(props: any) {
   return (
-    <ThemeProvider themes={['sunny', 'rainy', 'snowy']}>
+    <ThemeProvider themes={['sunny', 'rainy', 'snowy']} defaultTheme="sunny">
       <QueryClientProvider client={queryClient}>
         <ReactQueryStreamedHydration>
           {props.children}

--- a/src/components/common/Input/Input.module.scss
+++ b/src/components/common/Input/Input.module.scss
@@ -1,3 +1,7 @@
+.container {
+  position: relative;
+}
+
 .input {
   border-radius: 12px;
   @include text-style(16);
@@ -31,4 +35,13 @@
       }
     }
   }
+}
+
+.icon {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  width: 20px;
+  transform: translateY(-50%);
+  cursor: pointer;
 }

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import classNames from 'classnames/bind'
 import styles from './Input.module.scss'
+import { Eye, EyeOff } from 'lucide-react'
 
 const cx = classNames.bind(styles)
 
@@ -14,16 +15,30 @@ interface InputProps {
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ size, type, id, placeholder, maxLength, ...props }, ref) => {
+    const [typeState, setTypeState] = useState(type)
+
+    const handleTypeChange = () => {
+      setTypeState((prev) => (prev === 'password' ? 'text' : 'password'))
+    }
+
     return (
-      <input
-        className={cx('input', `input-size-${size}`)}
-        type={type}
-        id={id}
-        placeholder={placeholder}
-        maxLength={maxLength}
-        ref={ref}
-        {...props}
-      />
+      <div className={cx('container')}>
+        <input
+          className={cx('input', `input-size-${size}`)}
+          type={typeState}
+          id={id}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          ref={ref}
+          {...props}
+        />
+        {type === 'password' &&
+          (typeState === 'text' ? (
+            <Eye className={cx('icon')} onClick={handleTypeChange} />
+          ) : (
+            <EyeOff className={cx('icon')} onClick={handleTypeChange} />
+          ))}
+      </div>
     )
   }
 )

--- a/src/components/home/QuestionForm/QuestionForm.tsx
+++ b/src/components/home/QuestionForm/QuestionForm.tsx
@@ -1,11 +1,6 @@
 import { useState } from 'react'
 import Image from 'next/image'
-import {
-  useForm,
-  SubmitHandler,
-  FieldValues,
-  FormProvider
-} from 'react-hook-form'
+import { useForm, SubmitHandler, FieldValues } from 'react-hook-form'
 import classNames from 'classnames/bind'
 import { Plus, X } from 'lucide-react'
 
@@ -66,149 +61,148 @@ const QuestionForm = () => {
 
     const newValue = { ...values, ...{ team: '2-3' } }
 
+    console.log(newValue)
     // mutate(newValue)
   }
 
   return (
-    <FormProvider {...methods}>
-      <form className={cx('form')} onSubmit={handleSubmit(onSubmit)}>
-        <div className={cx('form-field')}>
-          <div>
-            <label className={cx('label')} htmlFor="question">
-              질문 내용
+    <form className={cx('form')} onSubmit={handleSubmit(onSubmit)}>
+      <div className={cx('form-field')}>
+        <div>
+          <label className={cx('label')} htmlFor="question">
+            질문 내용
+          </label>
+          <Textarea
+            id="question"
+            placeholder={PLACEHOLDER.question}
+            maxLength={30}
+            {...register('question', {
+              required: ERROR_MESSAGE.question.required,
+              minLength: { value: 5, message: ERROR_MESSAGE.question.min },
+              maxLength: { value: 30, message: ERROR_MESSAGE.question.max }
+            })}
+          />
+          {errors.question && (
+            <p className={cx('form-field-message')}>
+              {errors.question.message?.toString()}
+            </p>
+          )}
+        </div>
+        <div className={cx('responsive-flex')}>
+          <div className={cx('responsive-flex-item')}>
+            <label className={cx('label')} htmlFor="nickName">
+              닉네임
             </label>
-            <Textarea
-              id="question"
-              placeholder={PLACEHOLDER.question}
-              maxLength={30}
-              {...register('question', {
-                required: ERROR_MESSAGE.question.required,
-                minLength: { value: 5, message: ERROR_MESSAGE.question.min },
-                maxLength: { value: 30, message: ERROR_MESSAGE.question.max }
+            <Input
+              id="nickName"
+              size="responsive"
+              type="text"
+              placeholder={PLACEHOLDER.nickname}
+              maxLength={4}
+              {...register('nickName', {
+                required: ERROR_MESSAGE.nickname.required,
+                maxLength: {
+                  value: 4,
+                  message: ERROR_MESSAGE.nickname.required
+                },
+                validate: (value) =>
+                  data.results.some(
+                    (user: GetRecipientsList) =>
+                      user.name.split('/')[0] === value
+                  )
+                    ? ERROR_MESSAGE.nickname.duplicate
+                    : true
               })}
             />
-            {errors.question && (
+            {errors.nickName && (
               <p className={cx('form-field-message')}>
-                {errors.question.message?.toString()}
+                {errors.nickName.message?.toString()}
               </p>
             )}
           </div>
-          <div className={cx('responsive-flex')}>
-            <div className={cx('responsive-flex-item')}>
-              <label className={cx('label')} htmlFor="nickName">
-                닉네임
-              </label>
-              <Input
-                id="nickName"
-                size="responsive"
-                type="text"
-                placeholder={PLACEHOLDER.nickname}
-                maxLength={4}
-                {...register('nickName', {
-                  required: ERROR_MESSAGE.nickname.required,
-                  maxLength: {
-                    value: 4,
-                    message: ERROR_MESSAGE.nickname.required
-                  },
-                  validate: (value) =>
-                    data.results.some(
-                      (user: GetRecipientsList) =>
-                        user.name.split('/')[0] === value
-                    )
-                      ? ERROR_MESSAGE.nickname.duplicate
-                      : true
-                })}
-              />
-              {errors.nickName && (
-                <p className={cx('form-field-message')}>
-                  {errors.nickName.message?.toString()}
-                </p>
-              )}
-            </div>
-            <div className={cx('responsive-flex-item')}>
-              <label className={cx('label')} htmlFor="password">
-                비밀번호
-              </label>
-              <Input
-                id="password"
-                size="responsive"
-                type="text"
-                placeholder={PLACEHOLDER.password}
-                maxLength={4}
-                {...register('password', {
-                  required: ERROR_MESSAGE.password.required,
-                  minLength: {
-                    value: 4,
-                    message: ERROR_MESSAGE.password.letters
-                  },
-                  maxLength: {
-                    value: 4,
-                    message: ERROR_MESSAGE.password.letters
-                  },
-                  pattern: {
-                    value: /^\d{4}$/,
-                    message: ERROR_MESSAGE.password.number
-                  }
-                })}
-              />
-              {errors.password && (
-                <p className={cx('form-field-message')}>
-                  {errors.password.message?.toString()}
-                </p>
-              )}
-            </div>
-          </div>
-          <div>
-            <label className={cx('label')} htmlFor="category">
-              분야
+          <div className={cx('responsive-flex-item')}>
+            <label className={cx('label')} htmlFor="password">
+              비밀번호
             </label>
-            <Tags isAll={false} />
+            <Input
+              id="password"
+              size="responsive"
+              type="password"
+              placeholder={PLACEHOLDER.password}
+              maxLength={4}
+              {...register('password', {
+                required: ERROR_MESSAGE.password.required,
+                minLength: {
+                  value: 4,
+                  message: ERROR_MESSAGE.password.letters
+                },
+                maxLength: {
+                  value: 4,
+                  message: ERROR_MESSAGE.password.letters
+                },
+                pattern: {
+                  value: /^\d{4}$/,
+                  message: ERROR_MESSAGE.password.number
+                }
+              })}
+            />
+            {errors.password && (
+              <p className={cx('form-field-message')}>
+                {errors.password.message?.toString()}
+              </p>
+            )}
           </div>
-          <div>
-            <label className={cx('label')}>사진 (선택)</label>
-            <div className={cx('form-field-image')}>
-              {imagePreview ? (
-                <div
-                  className={cx('form-field-image-wrap')}
-                  onClick={handleResetImage}
-                >
-                  <div className={cx('form-field-image-preview')}>
-                    <Image
-                      className={cx('form-field-image-preview-cover')}
-                      src={imagePreview}
-                      alt="질문 등록 첨부 사진"
-                      fill
-                      sizes="100%"
-                    />
-                  </div>
-                  <X className={cx('form-field-image-wrap-icon')} />
-                </div>
-              ) : (
-                <>
-                  <label
-                    className={cx('form-field-image-label')}
-                    htmlFor="backgroundImageSelect"
-                  >
-                    <Plus className={cx('form-field-image-icon')} />
-                  </label>
-                  <input
-                    className={cx('form-field-image-input')}
-                    id="backgroundImageSelect"
-                    type="file"
-                    {...register('backgroundImageSelect', {
-                      onChange: (value) => handleCreateImageUrl(value)
-                    })}
+        </div>
+        <div>
+          <label className={cx('label')} htmlFor="category">
+            분야
+          </label>
+          <Tags isAll={false} {...register('backgroundColor')} />
+        </div>
+        <div>
+          <label className={cx('label')}>사진 (선택)</label>
+          <div className={cx('form-field-image')}>
+            {imagePreview ? (
+              <div
+                className={cx('form-field-image-wrap')}
+                onClick={handleResetImage}
+              >
+                <div className={cx('form-field-image-preview')}>
+                  <Image
+                    className={cx('form-field-image-preview-cover')}
+                    src={imagePreview}
+                    alt="질문 등록 첨부 사진"
+                    fill
+                    sizes="100%"
                   />
-                </>
-              )}
-            </div>
+                </div>
+                <X className={cx('form-field-image-wrap-icon')} />
+              </div>
+            ) : (
+              <>
+                <label
+                  className={cx('form-field-image-label')}
+                  htmlFor="backgroundImageSelect"
+                >
+                  <Plus className={cx('form-field-image-icon')} />
+                </label>
+                <input
+                  className={cx('form-field-image-input')}
+                  id="backgroundImageSelect"
+                  type="file"
+                  {...register('backgroundImageSelect', {
+                    onChange: (value) => handleCreateImageUrl(value)
+                  })}
+                />
+              </>
+            )}
           </div>
         </div>
-        <div className={cx('button')}>
-          <Button text="질문하기" size="full" type="submit" />
-        </div>
-      </form>
-    </FormProvider>
+      </div>
+      <div className={cx('button')}>
+        <Button text="질문하기" size="full" type="submit" />
+      </div>
+    </form>
   )
 }
 


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
1. QuestionForm에서 tag 컴포넌트 사용하는 코드를 register로 수정하였습니다.
2. 비밀번호 입력창 오른쪽에 눈 아이콘을 설정하여 아이콘을 클릭했을 때 보이거나 안보이도록 변경되는 기능을 구현하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #74 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/96277798/2e0c8023-fb37-4b34-8f0f-f67cf1e1cfdd)
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/96277798/d5aec3a8-1eb8-4613-9aec-26dee2b2ab89)