### PR TITLE
이미지 불러올 때까지 버튼 비활성화 및 스피너 추가

### DIFF
--- a/src/components/common/Button/Button.module.scss
+++ b/src/components/common/Button/Button.module.scss
@@ -3,9 +3,12 @@
   width: fit-content;
   margin: 0 auto;
   border-radius: 12px;
+  white-space: nowrap;
   overflow: hidden;
 
-  white-space: nowrap;
+  &:disabled {
+    background-color: $gray10;
+  }
 
   &-size {
     &-full {
@@ -36,7 +39,7 @@
       background-color: $secondary;
       border: none;
 
-      &:hover::after {
+      &:hover::after:not(:disabled) {
         position: absolute;
         top: 0;
         right: 0;
@@ -55,7 +58,7 @@
       background-color: $white;
       border: 1px solid $secondary;
 
-      &:hover::after {
+      &:hover::after:not(:disabled) {
         position: absolute;
         top: 0;
         right: 0;

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -8,6 +8,7 @@ interface ButtonProps {
   size: 'full' | 'lg' | 'md' | 'sm'
   type: 'button' | 'submit'
   variant?: 'default' | 'another'
+  isDisabled?: boolean
   onClick?: () => void
 }
 const Button = ({
@@ -15,6 +16,7 @@ const Button = ({
   size,
   type,
   variant = 'default',
+  isDisabled,
   onClick
 }: ButtonProps) => {
   return (
@@ -26,6 +28,7 @@ const Button = ({
       )}
       type={type}
       onClick={onClick}
+      disabled={isDisabled}
     >
       {text}
     </button>

--- a/src/components/common/Card/Card.module.scss
+++ b/src/components/common/Card/Card.module.scss
@@ -2,7 +2,9 @@
   display: flex;
   padding: 12px 16px;
   flex-direction: column;
+  justify-content: space-between;
   width: 100%;
+  height: 212px;
   border-radius: 16px;
   box-shadow: $main-shadow;
   box-sizing: border-box;
@@ -17,7 +19,6 @@
   &-text {
     color: $black;
     @include text-style(16);
-    height: 86px;
   }
 
   &-footer {

--- a/src/components/common/Input/Input.module.scss
+++ b/src/components/common/Input/Input.module.scss
@@ -42,6 +42,7 @@
   top: 50%;
   right: 16px;
   width: 20px;
+  color: $gray20;
   transform: translateY(-50%);
   cursor: pointer;
 }

--- a/src/components/common/Reaction/Reaction.module.scss
+++ b/src/components/common/Reaction/Reaction.module.scss
@@ -1,5 +1,6 @@
 .reaction {
-  padding: 4px 8px;
+  @include text-style(14);
+  padding: 2px 8px;
   border-radius: 36px;
   border: 1px solid $secondary;
   color: $secondary;

--- a/src/components/home/CurationCardList/CurationCardList.module.scss
+++ b/src/components/home/CurationCardList/CurationCardList.module.scss
@@ -1,10 +1,6 @@
 .viewer {
   height: 220px;
   overflow: hidden;
-
-  @include responsive(M) {
-    height: 160px;
-  }
 }
 
 .card-list {
@@ -15,7 +11,6 @@
   &-item {
     flex-shrink: 0;
     width: calc((100% - 32px) / 3);
-    background-color: $white;
 
     @include responsive(M) {
       width: calc((100% - 16px) / 2);

--- a/src/components/home/CurationCardList/CurationCardList.tsx
+++ b/src/components/home/CurationCardList/CurationCardList.tsx
@@ -1,11 +1,21 @@
 import { useState, useRef, useEffect } from 'react'
 import classNames from 'classnames/bind'
 
+import { useGetRecipientsList } from '@/hooks/useRecipients'
+import { GetRecipientsList } from '@/types/recipients'
 import registDragEvent from '@/utils/registDragEvent'
+import Card from '@/components/common/Card/Card'
 
 import styles from './CurationCardList.module.scss'
 
 const cx = classNames.bind(styles)
+
+interface CardType {
+  id: string
+  name: string
+  backgroundColor: 'beige' | 'purple' | 'blue' | 'green'
+  messageCount: number
+}
 
 const CurationCardList = () => {
   const [currentIndex, setCurrentIndex] = useState(0)
@@ -13,12 +23,12 @@ const CurationCardList = () => {
   const [cardWidth, setCardWidth] = useState(0)
   const [visibleCardCount, setVisibleCardCount] = useState(3)
 
+  const { data: cards } = useGetRecipientsList(100)
+
   const cardRef = useRef<HTMLLIElement>(null)
 
   const totalCards = 6
   const cardListGap = 16
-
-  const cards = Array.from({ length: totalCards }, (_, index) => index + 1)
 
   const inrange = (v: number, min: number, max: number) => {
     if (v < min) return min
@@ -83,11 +93,21 @@ const CurationCardList = () => {
           }
         })}
       >
-        {cards.map((card) => (
-          <li className={cx('card-list-item')} key={card} ref={cardRef}>
-            {card}
-          </li>
-        ))}
+        {cards?.results
+          .sort(
+            (a: GetRecipientsList, b: GetRecipientsList) =>
+              b.reactionCount - a.reactionCount
+          )
+          .map(({ id, name, backgroundColor, messageCount }: CardType) => (
+            <li className={cx('card-list-item')} ref={cardRef} key={id}>
+              <Card
+                id={id}
+                cardTitle={backgroundColor}
+                cardText={name}
+                answerCount={messageCount}
+              />
+            </li>
+          ))}
       </ul>
     </div>
   )

--- a/src/components/home/QuestionForm/QuestionForm.module.scss
+++ b/src/components/home/QuestionForm/QuestionForm.module.scss
@@ -52,11 +52,13 @@
     }
 
     &-image {
+      display: flex;
+      align-items: center;
+      justify-content: center;
       width: 140px;
       height: 140px;
       border: solid 1px $gray20;
       border-radius: 16px;
-      cursor: pointer;
       overflow: hidden;
 
       &-wrap {
@@ -65,6 +67,7 @@
         justify-content: center;
         width: 100%;
         height: 100%;
+        cursor: pointer;
 
         &-icon {
           position: absolute;
@@ -132,5 +135,23 @@
 
   @include responsive(M) {
     width: 100%;
+  }
+}
+
+.loader {
+  width: 28px;
+  height: 28px;
+  border: 3px solid $secondary;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
   }
 }

--- a/src/components/home/QuestionForm/QuestionForm.tsx
+++ b/src/components/home/QuestionForm/QuestionForm.tsx
@@ -34,7 +34,8 @@ const QuestionForm = () => {
 
   const { data } = useGetRecipientsList(100)
   const { mutate } = usePostRecipientsCreate()
-  const { mutate: getImageUrl } = usePostImageUrlCreate(setValue)
+  const { mutate: getImageUrl, isPending: isPendingGetImageUrl } =
+    usePostImageUrlCreate(setValue)
 
   const handleCreateImageUrl = async (
     value: React.ChangeEvent<HTMLInputElement>
@@ -61,8 +62,7 @@ const QuestionForm = () => {
 
     const newValue = { ...values, ...{ team: '2-3' } }
 
-    console.log(newValue)
-    // mutate(newValue)
+    mutate(newValue)
   }
 
   return (
@@ -103,7 +103,11 @@ const QuestionForm = () => {
                 required: ERROR_MESSAGE.nickname.required,
                 maxLength: {
                   value: 4,
-                  message: ERROR_MESSAGE.nickname.required
+                  message: ERROR_MESSAGE.nickname.max
+                },
+                pattern: {
+                  value: /^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]*$/,
+                  message: ERROR_MESSAGE.nickname.letters
                 },
                 validate: (value) =>
                   data.results.some(
@@ -162,45 +166,54 @@ const QuestionForm = () => {
         <div>
           <label className={cx('label')}>사진 (선택)</label>
           <div className={cx('form-field-image')}>
-            {imagePreview ? (
-              <div
-                className={cx('form-field-image-wrap')}
-                onClick={handleResetImage}
-              >
-                <div className={cx('form-field-image-preview')}>
-                  <Image
-                    className={cx('form-field-image-preview-cover')}
-                    src={imagePreview}
-                    alt="질문 등록 첨부 사진"
-                    fill
-                    sizes="100%"
-                  />
-                </div>
-                <X className={cx('form-field-image-wrap-icon')} />
-              </div>
-            ) : (
-              <>
-                <label
-                  className={cx('form-field-image-label')}
-                  htmlFor="backgroundImageSelect"
+            {!isPendingGetImageUrl ? (
+              imagePreview ? (
+                <div
+                  className={cx('form-field-image-wrap')}
+                  onClick={handleResetImage}
                 >
-                  <Plus className={cx('form-field-image-icon')} />
-                </label>
-                <input
-                  className={cx('form-field-image-input')}
-                  id="backgroundImageSelect"
-                  type="file"
-                  {...register('backgroundImageSelect', {
-                    onChange: (value) => handleCreateImageUrl(value)
-                  })}
-                />
-              </>
+                  <div className={cx('form-field-image-preview')}>
+                    <Image
+                      className={cx('form-field-image-preview-cover')}
+                      src={imagePreview}
+                      alt="질문 등록 첨부 사진"
+                      fill
+                      sizes="100%"
+                    />
+                  </div>
+                  <X className={cx('form-field-image-wrap-icon')} />
+                </div>
+              ) : (
+                <>
+                  <label
+                    className={cx('form-field-image-label')}
+                    htmlFor="backgroundImageSelect"
+                  >
+                    <Plus className={cx('form-field-image-icon')} />
+                  </label>
+                  <input
+                    className={cx('form-field-image-input')}
+                    id="backgroundImageSelect"
+                    type="file"
+                    {...register('backgroundImageSelect', {
+                      onChange: (value) => handleCreateImageUrl(value)
+                    })}
+                  />
+                </>
+              )
+            ) : (
+              <span className={cx('loader')}></span>
             )}
           </div>
         </div>
       </div>
       <div className={cx('button')}>
-        <Button text="질문하기" size="full" type="submit" />
+        <Button
+          text="질문하기"
+          size="full"
+          type="submit"
+          isDisabled={isPendingGetImageUrl}
+        />
       </div>
     </form>
   )

--- a/src/constants/formMessage.ts
+++ b/src/constants/formMessage.ts
@@ -8,6 +8,7 @@ export const ERROR_MESSAGE = {
     required: '닉네임을 입력해 주세요',
     max: '4자 이내로 입력해 주세요',
     duplicate: '이미 사용중인 닉네임입니다',
+    letters: '특수문자는 포함할 수 없습니다',
     register: '닉네임 또는 비밀번호를 확인해 주세요'
   },
   password: {

--- a/src/styles/variables/_box-shadow.scss
+++ b/src/styles/variables/_box-shadow.scss
@@ -1,2 +1,2 @@
-$main-shadow: 0 16px 32px 0 rgba(0 0 0 / 32%);
+$main-shadow: 0 4px 8px 0 rgba(0 0 0 / 32%);
 $popup-shadow: 0 4px 12px 0 rgba(0 0 0 / 32%);


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
1. 이미지 불러올 때까지 버튼에 disabled 설정하여 비활성화되도록 하였고 사진 첨부 컴포넌트에는 스피너가 나오도록 구현하였습니다.
2. Card 컴포넌트를 인기 질문에 나오도록 하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #77 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/96277798/2efe2430-a9b5-4cac-b7b9-769cfcc7e742)
