### PR TITLE
해당 card에 맞는 reaction 데이터 불러오기

### DIFF
--- a/src/components/common/Reaction/Reaction.tsx
+++ b/src/components/common/Reaction/Reaction.tsx
@@ -24,9 +24,11 @@ interface EmojiCounts {
 }
 
 const Reaction = ({ id, isHide }: ReactionProps) => {
+  console.log(`나는 몇번째 ${id}`)
   const { data } = useGetReaction(id) as { data: ReactionData }
   const { mutate } = usePostReaction(id)
 
+  console.log(data)
   const [clickState, setClickState] = useState<{ [key: string]: boolean }>({
     '😊': false,
     '🤣': false,
@@ -84,6 +86,7 @@ const Reaction = ({ id, isHide }: ReactionProps) => {
     return (
       (!isHide || count > 0) && (
         <button
+          key={emoji}
           className={cx('reaction')}
           onClick={() => handleClickCount(emoji)}
         >

--- a/src/components/common/Reaction/Reaction.tsx
+++ b/src/components/common/Reaction/Reaction.tsx
@@ -24,11 +24,9 @@ interface EmojiCounts {
 }
 
 const Reaction = ({ id, isHide }: ReactionProps) => {
-  console.log(`나는 몇번째 ${id}`)
   const { data } = useGetReaction(id) as { data: ReactionData }
   const { mutate } = usePostReaction(id)
 
-  console.log(data)
   const [clickState, setClickState] = useState<{ [key: string]: boolean }>({
     '😊': false,
     '🤣': false,

--- a/src/hooks/useRecipients.ts
+++ b/src/hooks/useRecipients.ts
@@ -34,7 +34,7 @@ export const usePostImageUrlCreate = (setValue: UseFormReturn['setValue']) =>
 
 export const useGetReaction = (id: string, limit?: number, offset?: number) =>
   useQuery({
-    queryKey: ['reaction'],
+    queryKey: ['reaction', id],
     queryFn: () => getRecipientsReactionsList(id, limit, offset)
   })
 


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- key값 추가 하였습니다.
- 해당 card에 맞는 reaction 데이터로 불러올수 있게 수정하였습니다.
- 새로고침 이슈는 확인해보니 문제 없이 작동되어서.. 다음 회의때 다시 같이 보면 좋을 것 같습니다!

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #79 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/84887815/66244f76-2cc5-4335-9ce0-5e8aa41bd774)
