### PR TITLE
질문 상세 페이지의 데이터와 로컬스토리지의 데이터 비교 함수 구현

### DIFF
--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation'
 import classNames from 'classnames/bind'
 
 import { useGetRecipientsRead } from '@/hooks/useRecipients'
-import AnswerEmpty from '@/components/questionDetail/AnswerEmpty/AnswerEmpty'
 
 import styles from './questiondetail.module.scss'
 
@@ -30,11 +29,7 @@ const QuestionDetailPage = () => {
     }
   })
 
-  return (
-    <div className={cx('container')}>
-      <AnswerEmpty userStatus={userState} />
-    </div>
-  )
+  return <div className={cx('container')}></div>
 }
 
 export default QuestionDetailPage

--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 import classNames from 'classnames/bind'
 
@@ -17,6 +17,18 @@ const QuestionDetailPage = () => {
   const { data } = useGetRecipientsRead(id)
 
   const [userState, setUserState] = useState<'question' | 'answer'>('answer')
+
+  useEffect(() => {
+    const localStorageData = localStorage.getItem('user')
+
+    if (localStorageData) {
+      JSON.parse(localStorageData).nickName === data?.name.split('/')[0] &&
+        JSON.parse(localStorageData).password === data?.name.split('/')[1] &&
+        setUserState('question')
+    } else {
+      setUserState('answer')
+    }
+  })
 
   return (
     <div className={cx('container')}>

--- a/src/components/questionDetail/AnswerEmpty/AnswerEmpty.tsx
+++ b/src/components/questionDetail/AnswerEmpty/AnswerEmpty.tsx
@@ -19,7 +19,7 @@ const AnswerEmpty = ({ userStatus }: AnswerEmpty) => {
         width={100}
         height={77}
       />
-      {userStatus ? (
+      {userStatus === 'answer' ? (
         <p>당신의 지식을 공유해주세요</p>
       ) : (
         <p>답변을 기다려 주세요</p>

--- a/src/hooks/useRecipients.ts
+++ b/src/hooks/useRecipients.ts
@@ -1,4 +1,4 @@
-import { redirect, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { UseFormReturn } from 'react-hook-form'
 
@@ -33,16 +33,9 @@ export const usePostRecipientsCreate = () => {
 
 export const useGetRecipientsRead = (id: string) =>
   useQuery({
-    queryKey: ['recipientsRead'],
-    queryFn: () => getRecipientsRead(id)
-  })
-
-export const useGetRecipientsRead = (id: string) => {
-  return useQuery({
     queryKey: ['recipientsRead', id],
     queryFn: () => getRecipientsRead(id)
   })
-}
 
 export const usePostImageUrlCreate = (setValue: UseFormReturn['setValue']) =>
   useMutation({


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
질문 상세 페이지에서 불러온 데이터와 로컬스토리지에서 가져온 데이터를 비교해서
데이터가 같으면 question 상태가 되고 아니면 answer 상태가 되도록 구현하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #98 

