### PR TITLE
Qusetion Detail 페이지 구현

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,9 @@
 const nextConfig = {
   sassOptions: {
     additionalData: '@import "@/styles/main.scss";'
+  },
+  images: {
+    domains: ['ifh.cc', 'i.ibb.co']
   }
 }
 

--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -57,6 +57,7 @@ const QuestionDetailPage = () => {
         ) : (
           recentMessages.map((answer: RecentMessages) => (
             <AnswerContent
+              key={answer.id}
               profileImage={answer.profileImageURL}
               nickname={answer.sender}
               date={answer.createdAt}

--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -55,15 +55,23 @@ const QuestionDetailPage = () => {
         {empty === 0 ? (
           <AnswerEmpty userStatus={userState} />
         ) : (
-          recentMessages.map((answer: RecentMessages) => (
-            <AnswerContent
-              key={answer.id}
-              profileImage={answer.profileImageURL}
-              nickname={answer.sender}
-              date={answer.createdAt}
-              answer={answer.content}
-            />
-          ))
+          recentMessages.map(
+            ({
+              id,
+              profileImageURL,
+              sender,
+              createdAt,
+              content
+            }: RecentMessages) => (
+              <AnswerContent
+                key={id}
+                profileImage={profileImageURL}
+                nickname={sender}
+                date={createdAt}
+                answer={content}
+              />
+            )
+          )
         )}
       </ContentLayout>
     </div>

--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -5,8 +5,14 @@ import { usePathname } from 'next/navigation'
 import classNames from 'classnames/bind'
 
 import { useGetRecipientsRead } from '@/hooks/useRecipients'
+import ReactionContent from '@/components/questionDetail/ReactionContent/ReactionContent'
+import ContentLayout from '@/components/questionDetail/ContentLayout/ContentLayout'
+import QuestionContent from '@/components/questionDetail/QuestionContent/QuestionContent'
+import AnswerEmpty from '@/components/questionDetail/AnswerEmpty/AnswerEmpty'
+import AnswerContent from '@/components/common/AnswerContent/AnswerContent'
 
 import styles from './questiondetail.module.scss'
+import { RecentMessages } from '@/types/recipients'
 
 const cx = classNames.bind(styles)
 
@@ -29,7 +35,38 @@ const QuestionDetailPage = () => {
     }
   })
 
-  return <div className={cx('container')}></div>
+  if (!data) {
+    return <div>Loading...</div>
+  }
+
+  const userId = data.id
+  const messageCount = data.messageCount
+  const empty = data.messageCount
+
+  const recentMessages = data.recentMessages
+
+  return (
+    <div className={cx('container')}>
+      <ReactionContent id={userId} />
+      <ContentLayout text="질문">
+        <QuestionContent id={userId} userStatus={userState} data={data} />
+      </ContentLayout>
+      <ContentLayout text="답변" messageCount={messageCount}>
+        {empty === 0 ? (
+          <AnswerEmpty userStatus={userState} />
+        ) : (
+          recentMessages.map((answer: RecentMessages) => (
+            <AnswerContent
+              profileImage={answer.profileImageURL}
+              nickname={answer.sender}
+              date={answer.createdAt}
+              answer={answer.content}
+            />
+          ))
+        )}
+      </ContentLayout>
+    </div>
+  )
 }
 
 export default QuestionDetailPage

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -7,7 +7,7 @@ import useDate from '@/hooks/useDate'
 const cx = classNames.bind(styles)
 
 const testData = {
-  src: 'https://images.unsplash.com/photo-1525351326368-efbb5cb6814d?q=80&w=1180&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  src: undefined,
   nickname: '김답변',
   date: new Date().toISOString(),
   answer: `병아리들은 애기때는 깃털이 아닌 솜털이에요!

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -7,7 +7,7 @@ import useDate from '@/hooks/useDate'
 const cx = classNames.bind(styles)
 
 const testData = {
-  src: undefined,
+  src: 'https://images.unsplash.com/photo-1525351326368-efbb5cb6814d?q=80&w=1180&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   nickname: '김답변',
   date: new Date().toISOString(),
   answer: `병아리들은 애기때는 깃털이 아닌 솜털이에요!

--- a/src/components/questionDetail/QuestionContent/QuestionContent.tsx
+++ b/src/components/questionDetail/QuestionContent/QuestionContent.tsx
@@ -8,35 +8,22 @@ import { useEffect, useState } from 'react'
 import { useModal } from '@/contexts/ModalProvider'
 import AlertModal from '@/components/common/AlertModal/AlertModal'
 import FormModal from '@/components/common/FormModal/FormModal'
+import { RecipientsDetailData } from '@/types/recipients'
 
 const cx = classNames.bind(styles)
 
 interface QuestionContentProps {
   id?: string
+  userStatus: 'question' | 'answer'
+  data: RecipientsDetailData
 }
 
-const QuestionContent = ({ id }: QuestionContentProps) => {
+const QuestionContent = ({ id, userStatus, data }: QuestionContentProps) => {
   if (id === undefined) {
     return <div>Invalid ID</div>
   }
-  const userId = window.localStorage.getItem('id')
-  const [answerUser, setAnswerUser] = useState(true)
 
-  useEffect(() => {
-    if (userId === id) {
-      setAnswerUser(false)
-    }
-    return () => {
-      setAnswerUser(true)
-    }
-  }, [id])
-
-  const { data } = useGetRecipientsRead(id)
   const getTagName = useChangeTagName()
-
-  if (!data) {
-    return <div>Loading...</div>
-  }
 
   const tagName = getTagName(data.backgroundColor)
   const name = data.name
@@ -71,7 +58,7 @@ const QuestionContent = ({ id }: QuestionContentProps) => {
         <span className={cx('questionDetails-date')}>{date}</span>
       </div>
       <div className={cx('questionText')}>{questionText}</div>
-      {answerUser && (
+      {userStatus && (
         <div className={cx('questionBtn')}>
           <Button
             text="답변하기"

--- a/src/components/questionDetail/QuestionContent/QuestionContent.tsx
+++ b/src/components/questionDetail/QuestionContent/QuestionContent.tsx
@@ -58,7 +58,7 @@ const QuestionContent = ({ id, userStatus, data }: QuestionContentProps) => {
         <span className={cx('questionDetails-date')}>{date}</span>
       </div>
       <div className={cx('questionText')}>{questionText}</div>
-      {userStatus && (
+      {userStatus === 'answer' && (
         <div className={cx('questionBtn')}>
           <Button
             text="답변하기"

--- a/src/types/recipients.ts
+++ b/src/types/recipients.ts
@@ -23,3 +23,26 @@ export interface PostRecipientsReactionsCreate {
   team?: string
   id?: string
 }
+
+export interface RecentMessages {
+  id: number
+  recipientId: number
+  sender: string
+  profileImageURL: string
+  relationship: string
+  content: string
+  font: string
+  createdAt: string
+}
+
+export interface RecipientsDetailData {
+  id: number
+  name: string
+  backgroundColor: 'beige' | 'purple' | 'blue' | 'green'
+  backgroundImageURL: string
+  createdAt: string
+  messageCount: number
+  recentMessages: RecentMessages[]
+  reactionCount: number
+  topReactions: any[]
+}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- Qusetion Detail 페이지 구현
- 사용자에 따라서 props로 UI 변경되도록 수정하였습니다.
- data를 Qusetion Detail 페이지에서 내려주는 방식으로 수정하였습니다.
- 이미지 파일 에러가 떠서 next.nextConfig 파일에 도메인 추가해두었습니다.

![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/84887815/cce69a11-e010-4780-9b53-5889a23b8a1d)


## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #100

## 스크린샷, 녹화

![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/84887815/ad8e4ed2-f6e3-4017-8b4a-2ebf04d013a0)
