### PR TITLE
AnswerContent의 비밀번호 입력 팝업, 사용자에 따라서 props로 UI 변경되도록 수정하기

### DIFF
--- a/src/components/common/AnswerContent/AnswerContent.module.scss
+++ b/src/components/common/AnswerContent/AnswerContent.module.scss
@@ -50,11 +50,12 @@
     }
 
     &-buttons {
+      position: relative;
       display: flex;
       align-items: flex-start;
       gap: 12px;
 
-      button {
+      &-button {
         border: 0;
         background-color: transparent;
         padding: 0;
@@ -67,6 +68,11 @@
           color: $primary;
         }
       }
+    }
+    &-pwpopup {
+      position: absolute;
+      top: 112%;
+      right: 0;
     }
   }
 

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -5,6 +5,9 @@ import { CheckCircle2, SquarePen, SquareX } from 'lucide-react'
 import useDate from '@/hooks/useDate'
 import PwPopUp from '../PopUp/PwPopUp'
 import { useState } from 'react'
+import { useModal } from '@/contexts/ModalProvider'
+import AlertModal from '../AlertModal/AlertModal'
+import Textarea from '../Textarea/Textarea'
 
 const cx = classNames.bind(styles)
 
@@ -12,11 +15,7 @@ const testData = {
   src: 'https://images.unsplash.com/photo-1525351326368-efbb5cb6814d?q=80&w=1180&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   nickname: '김답변',
   date: new Date().toISOString(),
-  answer: `병아리들은 애기때는 깃털이 아닌 솜털이에요!
-        부화한지 일주일정도 지나게 되면 노란 솜털이 빠지고하얀 깃털, 갈색 깃털
-        등 다양한 색의 깃털이 나오게 되는거죵.
-        쉽게말해 깃털 색이 노란색에서 하얀색으로 변화하는게 아닌 그냥 솜털
-        자체가 빠지면서 다른색깔인 새 깃털로 바뀐다는겁니다!`
+  answer: `병아리들은 애기때는 깃털이 아닌 솜털이에요! 부화한지 일주일정도 지나게 되면 노란 솜털이 빠지고하얀 깃털, 갈색 깃털 등 다양한 색의 깃털이 나오게 되는거죵. 쉽게말해 깃털 색이 노란색에서 하얀색으로 변화하는게 아닌 그냥 솜털 자체가 빠지면서 다른색깔인 새 깃털로 바뀐다는겁니다!`
 }
 
 interface AnswerContentProps {
@@ -24,6 +23,7 @@ interface AnswerContentProps {
   nickname: string
   date: string
   answer: string
+  userType: 'questioner' | 'respondent' | 'etc'
   onCheck: () => void
 }
 
@@ -31,24 +31,53 @@ const AnswerContent = ({
   profileImage = testData.src,
   nickname = testData.nickname,
   date = testData.date,
+  answer = testData.answer,
+  userType = 'etc',
   onCheck
 }: AnswerContentProps) => {
   const formattedDate = useDate(date)
   const [isPopupOpen, setIsPopupOpen] = useState(false)
   const [popupMode, setPopupMode] = useState('')
+  const modalId = crypto.randomUUID()
+  const { openModal, closeModal } = useModal()
+  const [isTextareaOpen, setIsTextareaOpen] = useState(false)
 
   const handlePopupOpen = () => {
     setIsPopupOpen(!isPopupOpen)
   }
 
-  const onEdit = () => {
+  const handleEditButton = () => {
     handlePopupOpen()
     setPopupMode('edit')
   }
 
-  const onDelete = () => {
+  const handleDeleteButton = () => {
     handlePopupOpen()
     setPopupMode('delete')
+  }
+
+  const handlePopupCheck = () => {
+    if (popupMode === 'edit') {
+      setIsTextareaOpen(true)
+      handlePopupOpen()
+    } else if (popupMode === 'delete') {
+      handleTestModal()
+      handlePopupOpen()
+    }
+  }
+
+  const handleTestModal = () => {
+    openModal(
+      <AlertModal
+        onCancel={() => {
+          closeModal(modalId)
+        }}
+        onDelete={() => {
+          closeModal(modalId)
+        }}
+      />,
+      modalId
+    )
   }
 
   return (
@@ -67,33 +96,44 @@ const AnswerContent = ({
           </div>
           <p>{formattedDate}</p>
         </div>
-        <div className={cx('answercontent-top-buttons')}>
+        {userType === 'respondent' && (
+          <div className={cx('answercontent-top-buttons')}>
+            <button
+              onClick={handleEditButton}
+              className={cx('answercontent-top-buttons-button')}
+            >
+              <SquarePen />
+            </button>
+            <button
+              onClick={handleDeleteButton}
+              className={cx('answercontent-top-buttons-button')}
+            >
+              <SquareX />
+            </button>
+            {isPopupOpen && (
+              <div className={cx('answercontent-top-pwpopup')}>
+                <PwPopUp onCheck={() => handlePopupCheck()} />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      {isTextareaOpen ? (
+        <Textarea id="0" placeholder={answer} maxLength={30} />
+      ) : (
+        <p className={cx('answercontent-middle')}>{answer}</p>
+      )}
+      {userType === 'questioner' && (
+        <div className={cx('answercontent-bottom')}>
           <button
-            onClick={onEdit}
-            className={cx('answercontent-top-buttons-button')}
+            className={cx('answercontent-bottom-check')}
+            onClick={onCheck}
           >
-            <SquarePen />
+            <CheckCircle2 className={cx('answercontent-bottom-check-image')} />
+            <p>채택하기</p>
           </button>
-          <button
-            onClick={onDelete}
-            className={cx('answercontent-top-buttons-button')}
-          >
-            <SquareX />
-          </button>
-          {isPopupOpen && (
-            <div className={cx('answercontent-top-pwpopup')}>
-              <PwPopUp />
-            </div>
-          )}
         </div>
-      </div>
-      <p className={cx('answercontent-middle')}>{testData.answer}</p>
-      <div className={cx('answercontent-bottom')}>
-        <button className={cx('answercontent-bottom-check')} onClick={onCheck}>
-          <CheckCircle2 className={cx('answercontent-bottom-check-image')} />
-          <p>채택하기</p>
-        </button>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -3,6 +3,8 @@ import styles from './AnswerContent.module.scss'
 import Image from 'next/image'
 import { CheckCircle2, SquarePen, SquareX } from 'lucide-react'
 import useDate from '@/hooks/useDate'
+import PwPopUp from '../PopUp/PwPopUp'
+import { useState } from 'react'
 
 const cx = classNames.bind(styles)
 
@@ -22,8 +24,6 @@ interface AnswerContentProps {
   nickname: string
   date: string
   answer: string
-  onEdit: () => void
-  onDelete: () => void
   onCheck: () => void
 }
 
@@ -31,11 +31,26 @@ const AnswerContent = ({
   profileImage = testData.src,
   nickname = testData.nickname,
   date = testData.date,
-  onEdit,
-  onDelete,
   onCheck
 }: AnswerContentProps) => {
   const formattedDate = useDate(date)
+  const [isPopupOpen, setIsPopupOpen] = useState(false)
+  const [popupMode, setPopupMode] = useState('')
+
+  const handlePopupOpen = () => {
+    setIsPopupOpen(!isPopupOpen)
+  }
+
+  const onEdit = () => {
+    handlePopupOpen()
+    setPopupMode('edit')
+  }
+
+  const onDelete = () => {
+    handlePopupOpen()
+    setPopupMode('delete')
+  }
+
   return (
     <div className={cx('answercontent')}>
       <div className={cx('answercontent-top')}>
@@ -53,12 +68,23 @@ const AnswerContent = ({
           <p>{formattedDate}</p>
         </div>
         <div className={cx('answercontent-top-buttons')}>
-          <button onClick={onEdit}>
+          <button
+            onClick={onEdit}
+            className={cx('answercontent-top-buttons-button')}
+          >
             <SquarePen />
           </button>
-          <button onClick={onDelete}>
+          <button
+            onClick={onDelete}
+            className={cx('answercontent-top-buttons-button')}
+          >
             <SquareX />
           </button>
+          {isPopupOpen && (
+            <div className={cx('answercontent-top-pwpopup')}>
+              <PwPopUp />
+            </div>
+          )}
         </div>
       </div>
       <p className={cx('answercontent-middle')}>{testData.answer}</p>

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -6,8 +6,8 @@ import useDate from '@/hooks/useDate'
 import PwPopUp from '../PopUp/PwPopUp'
 import { useState } from 'react'
 import { useModal } from '@/contexts/ModalProvider'
-import AlertModal from '../AlertModal/AlertModal'
-import Textarea from '../Textarea/Textarea'
+import AlertModal from '@/components/common/AlertModal/AlertModal'
+import Textarea from '@/components/common/Textarea/Textarea'
 
 const cx = classNames.bind(styles)
 
@@ -23,7 +23,7 @@ interface AnswerContentProps {
   nickname: string
   date: string
   answer: string
-  userType: 'questioner' | 'respondent' | 'etc'
+  userType: 'question' | 'answer'
   onCheck: () => void
 }
 
@@ -32,7 +32,7 @@ const AnswerContent = ({
   nickname = testData.nickname,
   date = testData.date,
   answer = testData.answer,
-  userType = 'etc',
+  userType = 'question',
   onCheck
 }: AnswerContentProps) => {
   const formattedDate = useDate(date)
@@ -96,7 +96,7 @@ const AnswerContent = ({
           </div>
           <p>{formattedDate}</p>
         </div>
-        {userType === 'respondent' && (
+        {userType === 'answer' && (
           <div className={cx('answercontent-top-buttons')}>
             <button
               onClick={handleEditButton}
@@ -123,7 +123,7 @@ const AnswerContent = ({
       ) : (
         <p className={cx('answercontent-middle')}>{answer}</p>
       )}
-      {userType === 'questioner' && (
+      {userType === 'question' && (
         <div className={cx('answercontent-bottom')}>
           <button
             className={cx('answercontent-bottom-check')}

--- a/src/components/common/PopUp/PwPopUp.tsx
+++ b/src/components/common/PopUp/PwPopUp.tsx
@@ -7,7 +7,9 @@ import { ERROR_MESSAGE } from '@/constants/formMessage'
 
 const cx = classNames.bind(styles)
 
-interface PwPopUpProps {}
+interface PwPopUpProps {
+  onCheck: () => void
+}
 
 type PwPopUpFormValues = {
   password: string
@@ -15,7 +17,7 @@ type PwPopUpFormValues = {
 
 const pwmessage = ERROR_MESSAGE.password
 
-const PwPopUp = ({}: PwPopUpProps) => {
+const PwPopUp = ({ onCheck }: PwPopUpProps) => {
   const {
     register,
     formState: { errors },
@@ -24,6 +26,7 @@ const PwPopUp = ({}: PwPopUpProps) => {
 
   const onSubmit: SubmitHandler<PwPopUpFormValues> = (data) => {
     console.log(data)
+    onCheck()
   }
 
   return (


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- 상단 이미지 버튼을 누르면 PwPopup이 출현하게 했습니다. 버튼의 유형은 state로 처리하였습니다.
- PwPopup에 onCheck 이벤트를 추가하여 상위 컴포넌트에서 제출 성공 유무를 체크할 수 있도록 하였습니다. 제출 성공 시 PwPopup이 사라집니다.
- Edit 버튼에서 비밀번호 제출 성공하면 본문이 Textarea로 변경됩니다.
- Delete 버튼에서 비밀번호 제출 성공하면 AlertModal이 출현합니다...지만 stroybook에서는 체크가 안되더라고요. 나중에 페이지 만들 때 확인해보고 안되면 그 때 다시 수정하겠습니다.
- userType 프롭 추가하였습니다. userType에 따라 보이는 값이 다릅니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #97 

## 스크린샷, 녹화
