### PR TITLE
Modal 바깥쪽 클릭시 닫히는 기능 구현

### DIFF
--- a/src/components/common/ModalWrapper/ModalWrapper.tsx
+++ b/src/components/common/ModalWrapper/ModalWrapper.tsx
@@ -21,11 +21,7 @@ function ModalWrapper({ children, id, onRemove }: Props) {
     }
 
     const handleClickOutside = (e: MouseEvent) => {
-      if (
-        ref.current &&
-        e.target instanceof Node &&
-        !ref.current.contains(e.target)
-      ) {
+      if (ref.current && e.target instanceof Node && ref.current === e.target) {
         onRemove(id)
       }
     }


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [x] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- 이미 구현되어 있던 ```handleClickOutside``` 함수가 작동되지 않던 버그를 수정하였습니다.
- 참고로 Esc 눌러도 모달 사라집니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #107

## 스크린샷, 녹화
