### PR TITLE
채택 기능 및 팝업 바깥쪽 클릭 시 닫히도록 구현

### DIFF
--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -4,6 +4,10 @@ import { useState, useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 import classNames from 'classnames/bind'
 
+import {
+  PostRecipientsReactionsCreate,
+  RecentMessages
+} from '@/types/recipients'
 import { useGetRecipientsRead } from '@/hooks/useRecipients'
 import ReactionContent from '@/components/questionDetail/ReactionContent/ReactionContent'
 import ContentLayout from '@/components/questionDetail/ContentLayout/ContentLayout'
@@ -12,14 +16,13 @@ import AnswerEmpty from '@/components/questionDetail/AnswerEmpty/AnswerEmpty'
 import AnswerContent from '@/components/common/AnswerContent/AnswerContent'
 
 import styles from './questiondetail.module.scss'
-import { RecentMessages } from '@/types/recipients'
 
 const cx = classNames.bind(styles)
 
 const QuestionDetailPage = () => {
   const params = usePathname()
-  const id = params.split('/')[2]
-  const { data } = useGetRecipientsRead(id)
+  const questionId = params.split('/')[2]
+  const { data } = useGetRecipientsRead(questionId)
 
   const [userState, setUserState] = useState<'question' | 'answer'>('answer')
 
@@ -44,12 +47,20 @@ const QuestionDetailPage = () => {
   const empty = data.messageCount
 
   const recentMessages = data.recentMessages
+  const checkId = data?.topReactions.find(
+    (reaction: PostRecipientsReactionsCreate) => reaction.emoji.includes('/')
+  )?.emoji
 
   return (
     <div className={cx('container')}>
       <ReactionContent id={userId} />
       <ContentLayout text="질문">
-        <QuestionContent id={userId} userStatus={userState} data={data} />
+        <QuestionContent
+          id={userId}
+          userStatus={userState}
+          data={data}
+          isChecked={checkId}
+        />
       </ContentLayout>
       <ContentLayout text="답변" messageCount={messageCount}>
         {empty === 0 ? (
@@ -65,10 +76,13 @@ const QuestionDetailPage = () => {
             }: RecentMessages) => (
               <AnswerContent
                 key={id}
+                answerId={String(id)}
+                questionId={questionId}
                 profileImage={profileImageURL}
                 nickname={sender}
                 date={createdAt}
                 answer={content}
+                checkId={checkId}
               />
             )
           )

--- a/src/components/common/AnswerContent/AnswerContent.module.scss
+++ b/src/components/common/AnswerContent/AnswerContent.module.scss
@@ -10,8 +10,28 @@
   border: 1px solid $secondary;
   width: 100%;
 
-  @include responsive(T){
+  @include responsive(T) {
     padding: 16px;
+  }
+
+  &-check {
+    position: relative;
+    border: 1px solid $primary;
+
+    &::after {
+      @include text-style(14, bold);
+      display: flex;
+      position: absolute;
+      top: -14px;
+      left: 52px;
+      height: 28px;
+      padding: 0 24px;
+      align-items: center;
+      background-color: $primary;
+      color: $white;
+      border-radius: 99px;
+      content: '질문자 채택';
+    }
   }
 
   &-top {
@@ -34,7 +54,7 @@
         gap: 8px;
 
         p {
-          @include text-style-16
+          @include text-style-16;
         }
       }
 
@@ -45,7 +65,7 @@
       p {
         margin: 0;
         color: $gray20;
-        @include text-style-14
+        @include text-style-14;
       }
     }
 
@@ -112,7 +132,7 @@
 
       p {
         margin: 0;
-        @include text-style-16
+        @include text-style-16;
       }
     }
   }

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -3,7 +3,8 @@ import styles from './AnswerContent.module.scss'
 import Image from 'next/image'
 import { CheckCircle2, SquarePen, SquareX } from 'lucide-react'
 import useDate from '@/hooks/useDate'
-import PwPopUp from '../PopUp/PwPopUp'
+import { usePostReaction } from '@/hooks/useRecipients'
+import PwPopUp from '@/components/common/PopUp/PwPopUp'
 import { useState } from 'react'
 import { useModal } from '@/contexts/ModalProvider'
 import AlertModal from '@/components/common/AlertModal/AlertModal'
@@ -19,20 +20,26 @@ const testData = {
 }
 
 interface AnswerContentProps {
+  answerId: string
+  questionId: string
   profileImage: string
   nickname: string
   date: string
   answer: string
+  checkId: string
   userType: 'question' | 'answer'
   onCheck: () => void
 }
 
 const AnswerContent = ({
+  answerId,
+  questionId,
   profileImage = testData.src,
   nickname = testData.nickname,
   date = testData.date,
   answer = testData.answer,
-  userType = 'question',
+  checkId,
+  userType = 'answer',
   onCheck
 }: AnswerContentProps) => {
   const formattedDate = useDate(date)
@@ -42,6 +49,8 @@ const AnswerContent = ({
   const { openModal, closeModal } = useModal()
   const [isTextareaOpen, setIsTextareaOpen] = useState(false)
 
+  const { mutate } = usePostReaction(questionId)
+  
   const handlePopupOpen = () => {
     setIsPopupOpen(!isPopupOpen)
   }
@@ -80,8 +89,16 @@ const AnswerContent = ({
     )
   }
 
+  const handleAnswerCheck = () => {
+    mutate({ emoji: `/${answerId}`, type: 'increase' })
+  }
+
   return (
-    <div className={cx('answercontent')}>
+    <div
+      className={cx('answercontent', {
+        'answercontent-check': checkId?.replace('/', '') === answerId
+      })}
+    >
       <div className={cx('answercontent-top')}>
         <div className={cx('answercontent-top-profile')}>
           <div>
@@ -127,7 +144,7 @@ const AnswerContent = ({
         <div className={cx('answercontent-bottom')}>
           <button
             className={cx('answercontent-bottom-check')}
-            onClick={onCheck}
+            onClick={handleAnswerCheck}
           >
             <CheckCircle2 className={cx('answercontent-bottom-check-image')} />
             <p>채택하기</p>

--- a/src/components/common/Button/Button.module.scss
+++ b/src/components/common/Button/Button.module.scss
@@ -39,7 +39,7 @@
       background-color: $secondary;
       border: none;
 
-      &:hover::after:not(:disabled) {
+      &:not(:disabled):hover::after {
         position: absolute;
         top: 0;
         right: 0;
@@ -58,7 +58,7 @@
       background-color: $white;
       border: 1px solid $secondary;
 
-      &:hover::after:not(:disabled) {
+      &:not(:disabled):hover::after {
         position: absolute;
         top: 0;
         right: 0;

--- a/src/components/common/Header/Header.module.scss
+++ b/src/components/common/Header/Header.module.scss
@@ -1,6 +1,7 @@
 .header {
   width: 100%;
   background-color: #f9f9f9;
+  border-bottom: 1px solid $gray20;
 
   height: 100px;
   @include responsive(T) {

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
@@ -17,10 +17,35 @@ const Header = () => {
   const [isOpenPopup, setIsOpenPopup] = useState(false)
   const { theme } = useTheme()
   const params = usePathname()
+  const buttonRef = useRef<HTMLDivElement>(null)
+  const popupRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     setMounted(true)
   }, [])
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target as Node) &&
+        popupRef.current &&
+        !popupRef.current.contains(e.target as Node)
+      ) {
+        setIsOpenPopup(false)
+      }
+    }
+
+    if (isOpenPopup) {
+      document.addEventListener('mousedown', handleClickOutside)
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpenPopup])
 
   const isParams = params.includes('questionlist')
 
@@ -45,7 +70,7 @@ const Header = () => {
         </Link>
         {isParams ? (
           <>
-            <div className={cx(`header-button`)}>
+            <div ref={buttonRef} className={cx(`header-button`)}>
               <Button
                 text="내 질문 찾기"
                 size="md"
@@ -55,7 +80,7 @@ const Header = () => {
               />
             </div>
             {isOpenPopup && (
-              <div className={cx('header-popup')}>
+              <div className={cx('header-popup')} ref={popupRef}>
                 <FindPopUp />
               </div>
             )}

--- a/src/components/common/Reaction/Reaction.module.scss
+++ b/src/components/common/Reaction/Reaction.module.scss
@@ -7,6 +7,10 @@
   background-color: $white;
   margin-right: 8px;
 
+  &-none {
+    pointer-events: none;
+  }
+
   &-emoji {
     display: inline-block;
     width: 16px;

--- a/src/components/common/Reaction/Reaction.tsx
+++ b/src/components/common/Reaction/Reaction.tsx
@@ -85,7 +85,7 @@ const Reaction = ({ id, isHide }: ReactionProps) => {
       (!isHide || count > 0) && (
         <button
           key={emoji}
-          className={cx('reaction')}
+          className={cx('reaction', { 'reaction-none': isHide })}
           onClick={() => handleClickCount(emoji)}
         >
           <span className={cx('reaction-emoji')}>{emoji}</span>

--- a/src/components/questionDetail/QuestionContent/QuestionContent.tsx
+++ b/src/components/questionDetail/QuestionContent/QuestionContent.tsx
@@ -16,9 +16,15 @@ interface QuestionContentProps {
   id?: string
   userStatus: 'question' | 'answer'
   data: RecipientsDetailData
+  isChecked: string | undefined
 }
 
-const QuestionContent = ({ id, userStatus, data }: QuestionContentProps) => {
+const QuestionContent = ({
+  id,
+  userStatus,
+  data,
+  isChecked
+}: QuestionContentProps) => {
   if (id === undefined) {
     return <div>Invalid ID</div>
   }
@@ -58,7 +64,7 @@ const QuestionContent = ({ id, userStatus, data }: QuestionContentProps) => {
         <span className={cx('questionDetails-date')}>{date}</span>
       </div>
       <div className={cx('questionText')}>{questionText}</div>
-      {userStatus === 'answer' && (
+      {userStatus === 'answer' && !isChecked && (
         <div className={cx('questionBtn')}>
           <Button
             text="답변하기"


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
1. 답변자가 한 질문을 채택 시 채택하기 버튼과 답변하기 버튼이 사라지고 답변의 스타일이 변경됩니다.
2. Find Popup 바깥쪽 클릭 시 팝업이 닫히도록 하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #108 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/96277798/9c868a8a-4ff6-4ebc-b197-7dc12b37ad8f)
