### PR TITLE
AnswerContent 및 PwPopup 관련 자잘한 수정

### DIFF
--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -83,6 +83,7 @@ const QuestionDetailPage = () => {
                 date={createdAt}
                 answer={content}
                 checkId={checkId}
+                userType={userState}
               />
             )
           )

--- a/src/components/common/AnswerContent/AnswerContent.module.scss
+++ b/src/components/common/AnswerContent/AnswerContent.module.scss
@@ -54,7 +54,7 @@
         gap: 8px;
 
         p {
-          @include text-style-16;
+          @include text-style(16);
         }
       }
 
@@ -65,7 +65,7 @@
       p {
         margin: 0;
         color: $gray20;
-        @include text-style-14;
+        @include text-style(14);
       }
     }
 
@@ -98,7 +98,7 @@
 
   &-middle {
     color: $black;
-    @include text-style-18;
+    @include text-style(18);
     width: 100%;
     margin: 0;
   }
@@ -132,7 +132,7 @@
 
       p {
         margin: 0;
-        @include text-style-16;
+        @include text-style(16);
       }
     }
   }

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -28,7 +28,7 @@ interface AnswerContentProps {
   answer: string
   checkId: string
   userType: 'question' | 'answer'
-  onCheck: () => void
+  onCheck?: () => void
 }
 
 const AnswerContent = ({

--- a/src/components/common/PopUp/PwPopUp.module.scss
+++ b/src/components/common/PopUp/PwPopUp.module.scss
@@ -8,7 +8,7 @@
   border: 1px solid $secondary;
   background-color: $white;
 
-  width: 160px;
+  width: 190px;
 
 
   &-label {

--- a/src/components/common/PopUp/PwPopUp.module.scss
+++ b/src/components/common/PopUp/PwPopUp.module.scss
@@ -31,7 +31,7 @@
   &-error {
     margin: 0;
 
-    @include text-style-12;
+    @include text-style(12);
     color: $red;
   }
 }


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [ ] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- PwPopup에서  눈 버튼이 input을 다 가리는 현상 수정하였습니다.
- questiondetail 페이지에서 AnswerContent에 userType 적용하였습니다.
- AnswerContent에서 무의미한 onCheck 프롭을 임시로 ? 처리하였습니다.
- 깜빡한 자잘한 text-style scss 적용 방식 수정하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #116

## 스크린샷, 녹화
