### PR TITLE
AnswerContent와 PwPopup 기능 작성(미완)

### DIFF
--- a/src/components/common/AlertModal/AlertModal.tsx
+++ b/src/components/common/AlertModal/AlertModal.tsx
@@ -24,7 +24,7 @@ const AlertModal = ({ onCancel, onDelete }: AlertModalProps) => {
           variant="another"
           onClick={onCancel}
         />
-        <Button text="답변하기" size="md" type="button" onClick={onDelete} />
+        <Button text="삭제하기" size="md" type="button" onClick={onDelete} />
       </div>
     </div>
   )

--- a/src/components/common/AnswerContent/AnswerContent.module.scss
+++ b/src/components/common/AnswerContent/AnswerContent.module.scss
@@ -89,10 +89,22 @@
         }
       }
     }
+
     &-pwpopup {
       position: absolute;
       top: 112%;
       right: 0;
+    }
+
+    &-textarea {
+      position: relative;
+      width: 100%;
+
+      &-button {
+        position: absolute;
+        bottom: 16px;
+        right: 16px;
+      }
     }
   }
 

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react'
 import { useModal } from '@/contexts/ModalProvider'
 import AlertModal from '@/components/common/AlertModal/AlertModal'
 import Textarea from '@/components/common/Textarea/Textarea'
+import { deleteRecipientsDelete } from '@/apis/recipients'
 
 const cx = classNames.bind(styles)
 
@@ -50,7 +51,7 @@ const AnswerContent = ({
   const [isTextareaOpen, setIsTextareaOpen] = useState(false)
 
   const { mutate } = usePostReaction(questionId)
-  
+
   const handlePopupOpen = () => {
     setIsPopupOpen(!isPopupOpen)
   }
@@ -70,18 +71,19 @@ const AnswerContent = ({
       setIsTextareaOpen(true)
       handlePopupOpen()
     } else if (popupMode === 'delete') {
-      handleTestModal()
+      handleAlertModal()
       handlePopupOpen()
     }
   }
 
-  const handleTestModal = () => {
+  const handleAlertModal = () => {
     openModal(
       <AlertModal
         onCancel={() => {
           closeModal(modalId)
         }}
         onDelete={() => {
+          deleteRecipientsDelete(answerId)
           closeModal(modalId)
         }}
       />,

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -10,6 +10,7 @@ import { useModal } from '@/contexts/ModalProvider'
 import AlertModal from '@/components/common/AlertModal/AlertModal'
 import Textarea from '@/components/common/Textarea/Textarea'
 import { deleteRecipientsDelete } from '@/apis/recipients'
+import Button from '../Button/Button'
 
 const cx = classNames.bind(styles)
 
@@ -49,6 +50,7 @@ const AnswerContent = ({
   const modalId = crypto.randomUUID()
   const { openModal, closeModal } = useModal()
   const [isTextareaOpen, setIsTextareaOpen] = useState(false)
+  const [answerEditValue, setAnswerEditValue] = useState('')
 
   const { mutate } = usePostReaction(questionId)
 
@@ -89,6 +91,14 @@ const AnswerContent = ({
       />,
       modalId
     )
+  }
+
+  const handleEditChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setAnswerEditValue(event.target.value)
+  }
+
+  const handleEditAnswer = () => {
+    console.log(answerEditValue)
   }
 
   const handleAnswerCheck = () => {
@@ -138,7 +148,22 @@ const AnswerContent = ({
         )}
       </div>
       {isTextareaOpen ? (
-        <Textarea id="0" placeholder={answer} maxLength={30} />
+        <div className={cx('answercontent-top-textarea')}>
+          <Textarea
+            id="0"
+            placeholder={answer}
+            maxLength={30}
+            onChange={handleEditChange}
+          />
+          <div className={cx('answercontent-top-textarea-button')}>
+            <Button
+              text="수정하기"
+              size="sm"
+              type="button"
+              onClick={() => handleEditAnswer()}
+            />
+          </div>
+        </div>
       ) : (
         <p className={cx('answercontent-middle')}>{answer}</p>
       )}

--- a/src/components/common/PopUp/PwPopUp.tsx
+++ b/src/components/common/PopUp/PwPopUp.tsx
@@ -23,10 +23,13 @@ const PwPopUp = ({ onCheck }: PwPopUpProps) => {
     formState: { errors },
     handleSubmit
   } = useForm<PwPopUpFormValues>()
+  const password = localStorage.getItem('password')
 
   const onSubmit: SubmitHandler<PwPopUpFormValues> = (data) => {
     console.log(data)
-    onCheck()
+    if (data.password === password) {
+      onCheck()
+    }
   }
 
   return (

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -9,10 +9,11 @@ interface TextareaProps {
   id: string
   placeholder: string
   maxLength?: number
+  onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
 }
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ id, placeholder, maxLength, ...props }, ref) => {
+  ({ id, placeholder, maxLength, onChange, ...props }, ref) => {
     return (
       <textarea
         className={cx('textarea')}
@@ -20,6 +21,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         placeholder={placeholder}
         ref={ref}
         maxLength={maxLength}
+        onChange={onChange}
         {...props}
       />
     )


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- PwPopup에 localstorage에서 password 값을 가져와서 현재 입력값과 비교하는 기능 추가 -> 추후 name에서 패스워드만 추출하여 이와 비교하도록 수정할 예정
- AnswerContent에서 편집 모드 들어가면 수정하기 버튼이 나타나도록 수정
- Answer 삭제 기능 추가(api 연결)
- Textarea의 변화값을 상위 컴포넌트로 올리는 onChange 프롭 추가
- 편집 api와 연결할 예정

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #120

## 스크린샷, 녹화
