### PR TITLE
질문에 첨부된 사진 나오도록 구현 

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,7 @@ const nextConfig = {
     additionalData: '@import "@/styles/main.scss";'
   },
   images: {
-    domains: ['ifh.cc', 'i.ibb.co']
+    domains: ['ifh.cc', 'i.ibb.co', 'ibb.co']
   }
 }
 

--- a/src/app/layout.module.scss
+++ b/src/app/layout.module.scss
@@ -1,6 +1,10 @@
 .container {
-  min-height: 100vh;
+  min-height: calc(100vh - 100px);
   background-color: $primary;
+
+  @include responsive(M) {
+    min-height: calc(100vh - 80px);
+  }
 }
 
 .main {

--- a/src/app/questionlist/questionlist.module.scss
+++ b/src/app/questionlist/questionlist.module.scss
@@ -36,9 +36,6 @@
   border-radius: 12px;
   background: $white;
   box-shadow: $main-shadow;
-  @include responsive(T) {
-    padding: 8px;
-  }
   @include responsive(M) {
     padding: 8px;
   }

--- a/src/components/common/NoAnswer/NoAnswer.module.scss
+++ b/src/components/common/NoAnswer/NoAnswer.module.scss
@@ -9,6 +9,7 @@
   box-shadow: $main-shadow;
   color: $secondary;
   gap: 8px;
+  cursor: pointer;
   @include text-style(18);
   @include responsive(M) {
     @include text-style(16);
@@ -16,17 +17,11 @@
     height: 48px;
     padding: 0 24px;
   }
-  label {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    gap: 8px;
-  }
 }
 .checkbox {
   @include responsive(M) {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
   }
 }
 .customCheckbox {

--- a/src/components/common/NoAnswer/NoAnswer.tsx
+++ b/src/components/common/NoAnswer/NoAnswer.tsx
@@ -19,7 +19,7 @@ const NoAnswer: React.FC<NoAnswerProps> = ({ setShowNoAnswer }) => {
   }
 
   return (
-    <div className={cx('button')}>
+    <label className={cx('button')} htmlFor="customCheckbox">
       <input
         className={cx('customCheckbox')}
         type="checkbox"
@@ -28,14 +28,12 @@ const NoAnswer: React.FC<NoAnswerProps> = ({ setShowNoAnswer }) => {
         onChange={handleCheckboxChange}
       />
       <span>미답변만 보기</span>
-      <label htmlFor="customCheckbox">
-        {isChecked ? (
-          <SquareCheck className={cx('checkbox')} />
-        ) : (
-          <Square className={cx('checkbox')} />
-        )}
-      </label>
-    </div>
+      {isChecked ? (
+        <SquareCheck className={cx('checkbox')} />
+      ) : (
+        <Square className={cx('checkbox')} />
+      )}
+    </label>
   )
 }
 

--- a/src/components/questionDetail/QuestionContent/QuestionContent.module.scss
+++ b/src/components/questionDetail/QuestionContent/QuestionContent.module.scss
@@ -56,6 +56,12 @@
   @include text-style(20, bold);
 }
 
+.questionImage {
+  max-width: 400px;
+  border-radius: 12px;
+  border: 1px solid $secondary;
+}
+
 .questionBtn {
   margin-left: auto;
 }

--- a/src/components/questionDetail/QuestionContent/QuestionContent.tsx
+++ b/src/components/questionDetail/QuestionContent/QuestionContent.tsx
@@ -36,6 +36,7 @@ const QuestionContent = ({
   const userName = name.split('/')[0]
   const questionText = name.split('/')[2]
   const date = useDate(data.createdAt)
+  const image = data.backgroundImageURL
 
   const modalId = crypto.randomUUID()
   const { openModal, closeModal } = useModal()
@@ -65,6 +66,13 @@ const QuestionContent = ({
           <span className={cx('questionDetails-date')}>{date}</span>
         </div>
         <div className={cx('questionText')}>{questionText}</div>
+        {image && (
+          <img
+            className={cx('questionImage')}
+            src={image}
+            alt="질문 첨부 사진"
+          />
+        )}
       </div>
       {userStatus === 'answer' && !isChecked && (
         <div className={cx('questionBtn')}>


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
1. 질문에 첨부된 사진이 나오도록 구현하였습니다. next.js의 Image를 사용하면 원본 이미지 비율이 유지되지 않아 img 태그를 사용했습니다.
2. 질문 리스트 페이지의 미답변만 보기 버튼의 label 태그를 최상위 태그로 만들어 버튼 아무 곳이나 클릭해도 이벤트가 발생하도록 수정하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #127 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/96277798/450c48a2-5c5c-43bf-bae7-bea2b89ada61)
