### PR TITLE
답변 등록 시 업데이트 안되는 현상 해결 및 답변 데이터 불러오는 함수 변경

### DIFF
--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -71,7 +71,7 @@ const QuestionDetailPage = () => {
           <AnswerEmpty userStatus={userState} />
         ) : (
           <div className={cx('answer-wrap')}>
-            {recentMessages.map(
+            {recentMessages?.map(
               ({
                 id,
                 profileImageURL,

--- a/src/app/questiondetail/[id]/page.tsx
+++ b/src/app/questiondetail/[id]/page.tsx
@@ -8,7 +8,10 @@ import {
   PostRecipientsReactionsCreate,
   RecentMessages
 } from '@/types/recipients'
-import { useGetRecipientsRead } from '@/hooks/useRecipients'
+import {
+  useGetRecipientsMessagesList,
+  useGetRecipientsRead
+} from '@/hooks/useRecipients'
 import ReactionContent from '@/components/questionDetail/ReactionContent/ReactionContent'
 import ContentLayout from '@/components/questionDetail/ContentLayout/ContentLayout'
 import QuestionContent from '@/components/questionDetail/QuestionContent/QuestionContent'
@@ -23,6 +26,7 @@ const QuestionDetailPage = () => {
   const params = usePathname()
   const questionId = params.split('/')[2]
   const { data } = useGetRecipientsRead(questionId)
+  const { data: answerListData } = useGetRecipientsMessagesList(questionId)
 
   const [userState, setUserState] = useState<'question' | 'answer'>('answer')
 
@@ -42,11 +46,11 @@ const QuestionDetailPage = () => {
     return <div>Loading...</div>
   }
 
-  const userId = data.id
+  const userId = String(data.id)
   const messageCount = data.messageCount
   const empty = data.messageCount
 
-  const recentMessages = data.recentMessages
+  const recentMessages = answerListData?.results
   const checkId = data?.topReactions.find(
     (reaction: PostRecipientsReactionsCreate) => reaction.emoji.includes('/')
   )?.emoji
@@ -66,7 +70,7 @@ const QuestionDetailPage = () => {
         {empty === 0 ? (
           <AnswerEmpty userStatus={userState} />
         ) : (
-          <div className={cx("answer-wrap")}>
+          <div className={cx('answer-wrap')}>
             {recentMessages.map(
               ({
                 id,

--- a/src/hooks/useRecipients.ts
+++ b/src/hooks/useRecipients.ts
@@ -9,7 +9,8 @@ import {
   getRecipientsReactionsList,
   postRecipientsReactionsCreate,
   getRecipientsRead,
-  postRecipientsMessagesCreate
+  postRecipientsMessagesCreate,
+  getRecipientsMessagesList
 } from '@/apis/recipients'
 import {
   PostRecipientsCreate,
@@ -57,6 +58,12 @@ export const usePostProfileImageUrlCreate = (
     }
   })
 
+export const useGetRecipientsMessagesList = (id: string) =>
+  useQuery({
+    queryKey: ['messagesList', id],
+    queryFn: () => getRecipientsMessagesList(id)
+  })
+
 export const usePostRecipientsMessagesCreate = (id: string) => {
   const router = useRouter()
   const queryClient = useQueryClient()
@@ -66,7 +73,7 @@ export const usePostRecipientsMessagesCreate = (id: string) => {
     onSuccess: (data) => {
       queryClient.invalidateQueries({
         queryKey: ['recipientsRead', id],
-        refetchType: 'inactive'
+        refetchType: 'active'
       })
       router.push(`/questiondetail/${data.recipientId}`)
     }


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [x] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
1. invalidateQueries의 refetchType를 active로 변경하여 답변 등록 시 업데이트 안되는 현상 해결했습니다.
2. 답변 목록이 3개까지만 나오는 api 함수를 변경하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #130 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/96277798/9e40041e-a2fc-41bb-80f8-bfea2023f26d)
