### PR TITLE
답변 삭제에 리액트 쿼리 적용하기

### DIFF
--- a/src/apis/messages.ts
+++ b/src/apis/messages.ts
@@ -22,7 +22,7 @@ export const patchMessagesPartialUpdate = async (
   return res.data
 }
 
-export const deleteMessagesDelete = async (id: number) => {
-  const res = await instance.get(`messages/${id}/`)
+export const deleteMessagesDelete = async (id: string) => {
+  const res = await instance.delete(`messages/${id}/`)
   return res.data
 }

--- a/src/components/common/AnswerContent/AnswerContent.tsx
+++ b/src/components/common/AnswerContent/AnswerContent.tsx
@@ -9,10 +9,6 @@ import { useEffect, useState } from 'react'
 import { useModal } from '@/contexts/ModalProvider'
 import AlertModal from '@/components/common/AlertModal/AlertModal'
 import Textarea from '@/components/common/Textarea/Textarea'
-import {
-  deleteMessagesDelete,
-  patchMessagesPartialUpdate
-} from '@/apis/messages'
 import Button from '@/components/common/Button/Button'
 import {
   useDeleteMessagesDelete,

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   getMessagesRead,
   putMessagesUpdate,
@@ -24,5 +24,7 @@ export const usePatchMessagesPartialUpdate = (id: string) =>
       patchMessagesPartialUpdate(id, value)
   })
 
-export const useDeleteMessagesDelete = (id: number) =>
-  useMutation({ mutationFn: () => deleteMessagesDelete(id) })
+export const useDeleteMessagesDelete = (id: string) =>
+  useMutation({
+    mutationFn: () => deleteMessagesDelete(id)
+  })


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- AlertModal에서 삭제하기 버튼을 눌렀을 때 해당 답변이 삭제되고, 또 리액트 쿼리에 의해 자동으로 리렌더링 되는 기능 추가하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #135

## 스크린샷, 녹화
https://github.com/Important-is-Great-Youths/QuickQuestion/assets/79896328/209ae599-2c12-463e-a1f3-cf885455c72c

