### PR TITLE
PwPopup이 질문자 채택 outline 아래로 렌더링 되는 현상 수정

### DIFF
--- a/src/components/common/AnswerContent/AnswerContent.module.scss
+++ b/src/components/common/AnswerContent/AnswerContent.module.scss
@@ -31,6 +31,7 @@
       color: $white;
       border-radius: 99px;
       content: '질문자 채택';
+      z-index: 1;
     }
   }
 

--- a/src/components/common/PopUp/PwPopUp.module.scss
+++ b/src/components/common/PopUp/PwPopUp.module.scss
@@ -7,6 +7,8 @@
   border-radius: 12px;
   border: 1px solid $secondary;
   background-color: $white;
+  z-index: 999;
+  position: relative;
 
   width: 190px;
 


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [ ] 기능 구현
- [x] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #145

## 스크린샷, 녹화
