### PR TITLE
중복 채택 금지 및 채택된 답변 수정, 삭제 버튼 안나오게 하기

### DIFF
--- a/src/components/common/AnswerContent/AnswerContent.module.scss
+++ b/src/components/common/AnswerContent/AnswerContent.module.scss
@@ -10,7 +10,7 @@
   border: 1px solid $secondary;
   width: 100%;
 
-  @include responsive(T) {
+  @include responsive(M) {
     padding: 16px;
   }
 
@@ -98,13 +98,32 @@
     }
 
     &-textarea {
-      position: relative;
       width: 100%;
+      margin-bottom: 12px;
 
-      &-button {
+      @include responsive(M) {
+        margin-bottom: 8px;
+      }
+
+      &-wrap {
+        position: relative;
+
+        &-button {
+          position: absolute;
+          bottom: 16px;
+          right: 16px;
+        }
+      }
+
+      &-message {
+        @include text-style(14);
         position: absolute;
-        bottom: 16px;
-        right: 16px;
+        color: $red;
+
+        @include responsive(M) {
+          @include text-style(12);
+          margin-top: 4px;
+        }
       }
     }
   }

--- a/src/components/common/FormModal/FormModal.module.scss
+++ b/src/components/common/FormModal/FormModal.module.scss
@@ -7,7 +7,7 @@
   padding: 28px;
   align-items: center;
   gap: 28px;
-  @include responsive(T) {
+  @include responsive(M) {
     padding: 20px;
     gap: 20px;
     width: 340px;
@@ -23,7 +23,7 @@
   background: $secondary;
   color: $white;
 
-  @include responsive(T) {
+  @include responsive(M) {
     padding: 16px;
   }
 
@@ -51,7 +51,7 @@
   border: 1px solid $secondary;
   width: 100%;
   padding: 24px;
-  @include responsive(T) {
+  @include responsive(M) {
     padding: 16px;
     gap: 28px;
   }
@@ -66,7 +66,7 @@
     color: $secondary;
     margin-bottom: 8px;
     @include text-style(20, bold);
-    @include responsive(T) {
+    @include responsive(M) {
       @include text-style(18, bold);
     }
   }
@@ -79,6 +79,8 @@
     justify-content: center;
     align-items: center;
     overflow: hidden;
+    cursor: pointer;
+
     .imgBox {
       display: none;
     }
@@ -95,8 +97,25 @@
   gap: 20px;
 }
 
-.error {
-  margin-top: 4px;
-  color: $red;
-  @include text-style-12;
+.input {
+  position: relative;
+
+  &-error {
+    @include text-style(14);
+    position: absolute;
+    color: $red;
+
+    @include responsive(M) {
+      @include text-style(12);
+      margin-top: 2px;
+    }
+  }
+}
+
+.textarea {
+  margin-bottom: 12px;
+
+  @include responsive(M) {
+    margin-bottom: 8px;
+  }
 }

--- a/src/components/common/FormModal/FormModal.tsx
+++ b/src/components/common/FormModal/FormModal.tsx
@@ -126,89 +126,95 @@ const FormModal: React.FC<FormModalProps> = ({ id, question, onClose }) => {
           </div>
           <div className={cx('content-container')}>
             <label className={cx('label')}>닉네임</label>
-            <Input
-              size="responsive"
-              type="text"
-              {...register('sender', {
-                required: {
-                  value: true,
-                  message: ERROR_MESSAGE.nickname.required
-                },
-                minLength: {
-                  value: 1,
-                  message: ERROR_MESSAGE.nickname.max
-                },
-                maxLength: {
-                  value: 4,
-                  message: ERROR_MESSAGE.nickname.max
-                },
-                pattern: {
-                  value: /^[A-Za-z0-9가-힣]*$/,
-                  message: ERROR_MESSAGE.nickname.letters
-                }
-              })}
-              placeholder={PLACEHOLDER.nickname}
-            />
-            {errors.sender && (
-              <p className={cx('error')}>{errors.sender.message?.toString()}</p>
-            )}
+            <div className={cx('input')}>
+              <Input
+                size="responsive"
+                type="text"
+                placeholder={PLACEHOLDER.nickname}
+                maxLength={4}
+                {...register('sender', {
+                  required: {
+                    value: true,
+                    message: ERROR_MESSAGE.nickname.required
+                  },
+                  maxLength: {
+                    value: 4,
+                    message: ERROR_MESSAGE.nickname.max
+                  },
+                  pattern: {
+                    value: /^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]*$/,
+                    message: ERROR_MESSAGE.nickname.letters
+                  }
+                })}
+              />
+              {errors.sender && (
+                <p className={cx('input-error')}>
+                  {errors.sender.message?.toString()}
+                </p>
+              )}
+            </div>
           </div>
           <div className={cx('content-container')}>
             <label className={cx('label')}>비밀번호</label>
-            <Input
-              size="responsive"
-              type="password"
-              {...register('password', {
-                required: {
-                  value: true,
-                  message: ERROR_MESSAGE.password.required
-                },
-                minLength: {
-                  value: 4,
-                  message: ERROR_MESSAGE.nickname.max
-                },
-                maxLength: {
-                  value: 4,
-                  message: ERROR_MESSAGE.password.letters
-                },
-                pattern: {
-                  value: /^[0-9]*$/,
-                  message: ERROR_MESSAGE.password.number
-                }
-              })}
-              placeholder={PLACEHOLDER.password}
-            />
-            {errors.password && (
-              <p className={cx('error')}>
-                {errors.password.message?.toString()}
-              </p>
-            )}
+            <div className={cx('input')}>
+              <Input
+                size="responsive"
+                type="password"
+                placeholder={PLACEHOLDER.password}
+                maxLength={4}
+                {...register('password', {
+                  required: {
+                    value: true,
+                    message: ERROR_MESSAGE.password.required
+                  },
+                  minLength: {
+                    value: 4,
+                    message: ERROR_MESSAGE.nickname.letters
+                  },
+                  maxLength: {
+                    value: 4,
+                    message: ERROR_MESSAGE.password.letters
+                  },
+                  pattern: {
+                    value: /^\d{4}$/,
+                    message: ERROR_MESSAGE.password.number
+                  }
+                })}
+              />
+              {errors.password && (
+                <p className={cx('input-error')}>
+                  {errors.password.message?.toString()}
+                </p>
+              )}
+            </div>
           </div>
-          <div className={cx('content-container')}>
+          <div className={cx('content-container', 'textarea')}>
             <label className={cx('label')}>답변 내용</label>
-            <Textarea
-              {...register('content', {
-                required: {
-                  value: true,
-                  message: ERROR_MESSAGE.answer.required
-                },
-                minLength: {
-                  value: 5,
-                  message: ERROR_MESSAGE.answer.min
-                },
-                maxLength: {
-                  value: 255,
-                  message: ERROR_MESSAGE.answer.max
-                }
-              })}
-              id="content"
-              placeholder={PLACEHOLDER.answer}
-            />
-            {errors.content && (
-              <p className={cx('error')}>
-                {errors.content.message?.toString()}
-              </p>
-            )}
+            <div className={cx('input')}>
+              <Textarea
+                {...register('content', {
+                  required: {
+                    value: true,
+                    message: ERROR_MESSAGE.answer.required
+                  },
+                  minLength: {
+                    value: 5,
+                    message: ERROR_MESSAGE.answer.min
+                  },
+                  maxLength: {
+                    value: 255,
+                    message: ERROR_MESSAGE.answer.max
+                  }
+                })}
+                id="content"
+                placeholder={PLACEHOLDER.answer}
+              />
+              {errors.content && (
+                <p className={cx('input-error')}>
+                  {errors.content.message?.toString()}
+                </p>
+              )}
+            </div>
           </div>
         </div>
         <div className={cx('button-container')}>

--- a/src/components/common/Textarea/Textarea.tsx
+++ b/src/components/common/Textarea/Textarea.tsx
@@ -8,17 +8,19 @@ const cx = classNames.bind(styles)
 interface TextareaProps {
   id: string
   placeholder: string
+  defaultValue?: string
   maxLength?: number
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
 }
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ id, placeholder, maxLength, onChange, ...props }, ref) => {
+  ({ id, placeholder, defaultValue, maxLength, onChange, ...props }, ref) => {
     return (
       <textarea
         className={cx('textarea')}
         id={id}
         placeholder={placeholder}
+        defaultValue={defaultValue}
         ref={ref}
         maxLength={maxLength}
         onChange={onChange}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
1. 채택된 답변이 있을 때는 채택하기 버튼이 나오지 않도록 수정하였습니다.
2. 채택된 답변은 수정, 삭제 버튼이 나오지 않게 수정하였습니다.
3. 답변 수정 시 기존 텍스트를 기본값으로 설정하였습니다.
4. 폼 모달의 validation을 고쳤습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #147 

## 스크린샷, 녹화
![image](https://github.com/Important-is-Great-Youths/QuickQuestion/assets/96277798/63497af0-caa0-4fd1-8e27-126d7c4308d5)
