### PR TITLE
변환된 위치값, 현재 날짜를 데이터 요청 url에 넣기 및 질문 없을 때 렌더링 될 요소 추가

### DIFF
--- a/src/apis/getWeather.ts
+++ b/src/apis/getWeather.ts
@@ -1,21 +1,11 @@
 import { instance } from '@/lib/axios'
 
-const getFormattedDate = () => {
-  const today = new Date()
-  const year = today.getFullYear()
-  const month = String(today.getMonth() + 1).padStart(2, '0')
-  const day = String(today.getDate()).padStart(2, '0')
-
-  return `${year}${month}${day}`
-}
-
-// 임시 코드
-const baseDate = getFormattedDate() // ex)20240603
-const baseTime = '0600'
-const nx = '63'
-const ny = '126'
-
-export const getWeather = async () => {
+export const getWeather = async (
+  baseDate: string,
+  baseTime: string,
+  nx: number,
+  ny: number
+) => {
   const res = await instance.get(
     `http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtNcst?serviceKey=${process.env.NEXT_PUBLIC_WEATHER_API_KEY}&dataType=JSON&base_date=${baseDate}&base_time=${baseTime}&nx=${nx}&ny=${ny}`
   )

--- a/src/app/questionlist/page.tsx
+++ b/src/app/questionlist/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import classNames from 'classnames/bind'
 import styles from './questionlist.module.scss'
 import { useGetRecipientsList } from '@/hooks/useRecipients'
@@ -10,6 +11,7 @@ import { Pagination } from '@/components/common/Pagination/Pagination'
 import Card from '@/components/common/Card/Card'
 import Tags from '@/components/common/Tags/Tags'
 import NoAnswer from '@/components/common/NoAnswer/NoAnswer'
+import Button from '@/components/common/Button/Button'
 
 const cx = classNames.bind(styles)
 
@@ -54,30 +56,37 @@ const QuestionListPage = () => {
         <NoAnswer setShowNoAnswer={setShowNoAnswer} />
       </div>
       {paginatedData.length > 0 ? (
-        <ul className={cx('cardContainer')}>
-          {paginatedData.map((question: GetRecipientsList) => (
-            <Card
-              key={question.id}
-              id={question.id.toString()}
-              cardTitle={question.backgroundColor}
-              cardText={question.name}
-              answerCount={question.messageCount}
+        <>
+          <ul className={cx('cardContainer')}>
+            {paginatedData.map((question: GetRecipientsList) => (
+              <Card
+                key={question.id}
+                id={question.id.toString()}
+                cardTitle={question.backgroundColor}
+                cardText={question.name}
+                answerCount={question.messageCount}
+              />
+            ))}
+          </ul>
+          <div className={cx('paginationContainer')}>
+            <Pagination
+              data={filteredData}
+              viewCount={viewCount}
+              totalCount={filteredData.length}
+              limit={limit}
+              currentPage={currentPage}
+              onPageChange={(page) => setCurrentPage(page)}
             />
-          ))}
-        </ul>
+          </div>
+        </>
       ) : (
-        <p className={cx('noQuestions')}>질문을 생성해주세요!</p>
+        <div className={cx('noQuestions')}>
+          <p className={cx('noQuestions-text')}>아직 등록된 질문이 없어요</p>
+          <Link className={cx('noQuestions-button')} href={'/'}>
+            <Button text="질문 등록하러 가기" size="lg" type="button" />
+          </Link>
+        </div>
       )}
-      <div className={cx('paginationContainer')}>
-        <Pagination
-          data={filteredData}
-          viewCount={viewCount}
-          totalCount={filteredData.length}
-          limit={limit}
-          currentPage={currentPage}
-          onPageChange={(page) => setCurrentPage(page)}
-        />
-      </div>
     </div>
   )
 }

--- a/src/app/questionlist/questionlist.module.scss
+++ b/src/app/questionlist/questionlist.module.scss
@@ -65,9 +65,23 @@
   align-items: flex-start;
   gap: 10px;
 }
+
 .noQuestions {
-  text-align: center;
-  font-size: 30px;
-  color: $white;
-  margin: 50px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  height: 200px;
+
+  &-text {
+    @include text-style(24, bold);
+    color: $white;
+  }
+
+  &-button {
+    width: fit-content;
+    border-radius: 12px;
+    box-shadow: $main-shadow;
+  }
 }

--- a/src/hooks/useGetWeather.ts
+++ b/src/hooks/useGetWeather.ts
@@ -3,12 +3,20 @@ import { useTheme } from 'next-themes'
 import { useQuery } from '@tanstack/react-query'
 
 import { getWeather } from '@/apis/getWeather'
+import { useBaseDate, useBaseTime } from '@/hooks/useDateAndTime'
+import { useLonLatToXY } from '@/hooks/useLonLatToXY'
 
 const useGetWeather = () => {
   const { setTheme } = useTheme()
+
+  const dateSlot = useBaseDate()
+  const timeSlot = useBaseTime()
+  const { x, y } = useLonLatToXY(126.980008333333, 37.5635694444444) // 임시값
+
   const { data } = useQuery({
     queryKey: ['weather'],
-    queryFn: () => getWeather()
+    queryFn: () => getWeather(dateSlot, timeSlot, x, y),
+    enabled: !!timeSlot
   })
 
   const obsrValueCode = data?.data.response.body.items.item[0].obsrValue


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [x] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
1. 사용자 위치가 nx과 ny로 변환된 값과 현재 날짜가 baseDate, baseTime으로 변환된 값을 hook으로 불러와 날씨 api url에 입력하였습니다.
2. 질문 리스트 페이지에 질문이 없을 때 렌더링 될 요소를 추가하였습니다.

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #160 
