### PR TITLE
페이지네이션 초기값 1로 해서 태그값 변경 시 1로 되도록 구현

### DIFF
--- a/src/app/questionlist/page.tsx
+++ b/src/app/questionlist/page.tsx
@@ -49,7 +49,13 @@ const QuestionListPage = () => {
 
       <div className={cx('header')}>
         <div className={cx('tagsContainer')}>
-          <Tags isAll onTagChange={(tag) => setSelectedTag(tag)} />
+          <Tags
+            isAll
+            onTagChange={(tag) => {
+              setSelectedTag(tag)
+              setCurrentPage(1)
+            }}
+          />
         </div>
         <NoAnswer setShowNoAnswer={setShowNoAnswer} />
       </div>


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] UI 구현
- [x] 기능 구현
- [ ] 버그 해결
- [ ] 리팩토링
- [ ] 최적화
- [ ] 테스트
- [ ] 환경 세팅

## 설명
- 태그값 변경 시 페이지네이션 초기값이 1로 되도록 구현

## 관련 문서

<!--
예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- close #162 

## 스크린샷, 녹화
